### PR TITLE
fix: buurt collectors — Open-Meteo 429 + Luchtmeetnet KeyError (CI 27068482501)

### DIFF
--- a/collectors/luchtmeetnet.py
+++ b/collectors/luchtmeetnet.py
@@ -202,23 +202,45 @@ class LuchtmeetnetCollector(BaseCollector):
         # Fetch details for each station
         for station in station_list:
             url = f"{self.base_url}/stations/{station['number']}/"
-            async with session.get(url) as response:
-                if response.status != 200:
-                    continue  # Skip stations with errors
+            try:
+                async with session.get(url) as response:
+                    if response.status != 200:
+                        continue  # Skip stations with errors
 
-                data = await response.json()
-                station_data = data['data']
+                    data = await response.json()
+                    station_data = data['data']
 
-                # Extract coordinates and metadata
-                if (station_data['geometry']['type'] == 'point' and
-                    station_data['geometry']['coordinates']):
-                    station['latitude'] = station_data['geometry']['coordinates'][1]
-                    station['longitude'] = station_data['geometry']['coordinates'][0]
-                    station['components'] = station_data.get('components', [])
-                    station['location'] = station_data.get('location', '')
-                    station['municipality'] = station_data.get('municipality', '')
+                    # Extract coordinates and metadata. Accept both 'point' (current
+                    # Luchtmeetnet behavior) and 'Point' (GeoJSON RFC 7946 standard)
+                    # so an upstream-spec correction doesn't silently break us.
+                    geom = (station_data or {}).get('geometry') or {}
+                    if (geom.get('type') in ('point', 'Point')
+                            and geom.get('coordinates')):
+                        station['latitude'] = geom['coordinates'][1]
+                        station['longitude'] = geom['coordinates'][0]
+                        station['components'] = station_data.get('components', [])
+                        station['location'] = station_data.get('location', '')
+                        station['municipality'] = station_data.get('municipality', '')
+            except Exception as e:
+                # Single-station network/parse failures must not poison the cache.
+                # Before this guard a single bad detail-fetch left the station in
+                # the list without lat/lon, causing the cached list to crash
+                # `closest()` with KeyError: 'latitude' for 24h (see CI run
+                # 27068482501, 2026-06-06).
+                self.logger.warning(
+                    f"Skipping station {station.get('number', '?')}: detail-fetch failed ({e})"
+                )
 
-        return station_list
+        # Drop any station that didn't get coordinates assigned. `closest()`
+        # iterates p['latitude'] over every member; a single missing entry
+        # raises KeyError and kills the whole collection.
+        clean = [s for s in station_list if 'latitude' in s and 'longitude' in s]
+        if len(clean) < len(station_list):
+            self.logger.info(
+                f"Filtered {len(station_list) - len(clean)} stations without coordinates "
+                f"({len(clean)}/{len(station_list)} usable)"
+            )
+        return clean
 
     async def _fetch_aqi(
         self,

--- a/collectors/openmeteo_offshore_wind.py
+++ b/collectors/openmeteo_offshore_wind.py
@@ -171,16 +171,25 @@ class OpenMeteoOffshoreWindCollector(BaseCollector):
         # Five Open-Meteo collectors share the API in data_fetcher.py (strategic
         # weather + solar, offshore wind, buurt weather + solar). Tightened from
         # Semaphore(2)+0.1s to Semaphore(1)+0.5s on 2026-06-06 after CI run
-        # 27068482501 saw all buurt + offshore locations hit HTTP 429.
+        # 27068482501 saw all buurt + offshore locations hit HTTP 429. The 0.5s
+        # gap is between requests only — no pre-first-request delay.
         semaphore = asyncio.Semaphore(1)
 
-        async def fetch_with_rate_limit(session: aiohttp.ClientSession, location: Dict[str, Any]):
+        async def fetch_with_rate_limit(
+            session: aiohttp.ClientSession,
+            location: Dict[str, Any],
+            delay: bool,
+        ):
             async with semaphore:
-                await asyncio.sleep(0.5)  # Inter-request gap (was 0.1, raised 2026-06-06)
+                if delay:
+                    await asyncio.sleep(0.5)  # Inter-request gap (was 0.1, raised 2026-06-06)
                 return await self._fetch_location_data(session, location)
 
         async with aiohttp.ClientSession() as session:
-            tasks = [fetch_with_rate_limit(session, loc) for loc in self.locations]
+            tasks = [
+                fetch_with_rate_limit(session, loc, delay=(i > 0))
+                for i, loc in enumerate(self.locations)
+            ]
             responses = await asyncio.gather(*tasks)
 
             for response in responses:

--- a/collectors/openmeteo_offshore_wind.py
+++ b/collectors/openmeteo_offshore_wind.py
@@ -167,12 +167,16 @@ class OpenMeteoOffshoreWindCollector(BaseCollector):
         self.logger.debug(f"Fetching offshore wind data for {len(self.locations)} locations")
 
         results = {}
-        # Use semaphore to limit concurrent requests and avoid rate limiting
-        semaphore = asyncio.Semaphore(2)  # Max 2 concurrent (3 collectors share Open-Meteo)
+        # Use semaphore to limit concurrent requests and avoid rate limiting (HTTP 429).
+        # Five Open-Meteo collectors share the API in data_fetcher.py (strategic
+        # weather + solar, offshore wind, buurt weather + solar). Tightened from
+        # Semaphore(2)+0.1s to Semaphore(1)+0.5s on 2026-06-06 after CI run
+        # 27068482501 saw all buurt + offshore locations hit HTTP 429.
+        semaphore = asyncio.Semaphore(1)
 
         async def fetch_with_rate_limit(session: aiohttp.ClientSession, location: Dict[str, Any]):
             async with semaphore:
-                await asyncio.sleep(0.1)  # Small delay between requests
+                await asyncio.sleep(0.5)  # Inter-request gap (was 0.1, raised 2026-06-06)
                 return await self._fetch_location_data(session, location)
 
         async with aiohttp.ClientSession() as session:

--- a/collectors/openmeteo_solar.py
+++ b/collectors/openmeteo_solar.py
@@ -162,12 +162,16 @@ class OpenMeteoSolarCollector(BaseCollector):
         self.logger.debug(f"Fetching solar data for {len(self.locations)} locations")
 
         results = {}
-        # Use semaphore to limit concurrent requests and avoid rate limiting (HTTP 429)
-        semaphore = asyncio.Semaphore(2)  # Max 2 concurrent (3 collectors share Open-Meteo)
+        # Use semaphore to limit concurrent requests and avoid rate limiting (HTTP 429).
+        # Five Open-Meteo collectors share the API in data_fetcher.py (strategic
+        # weather + solar, offshore wind, buurt weather + solar). Tightened from
+        # Semaphore(2)+0.1s to Semaphore(1)+0.5s on 2026-06-06 after CI run
+        # 27068482501 saw all buurt + offshore locations hit HTTP 429.
+        semaphore = asyncio.Semaphore(1)
 
         async def fetch_with_rate_limit(session: aiohttp.ClientSession, location: Dict[str, Any]):
             async with semaphore:
-                await asyncio.sleep(0.1)  # Small delay between requests
+                await asyncio.sleep(0.5)  # Inter-request gap (was 0.1, raised 2026-06-06)
                 return await self._fetch_location_data(session, location)
 
         async with aiohttp.ClientSession() as session:

--- a/collectors/openmeteo_solar.py
+++ b/collectors/openmeteo_solar.py
@@ -166,16 +166,25 @@ class OpenMeteoSolarCollector(BaseCollector):
         # Five Open-Meteo collectors share the API in data_fetcher.py (strategic
         # weather + solar, offshore wind, buurt weather + solar). Tightened from
         # Semaphore(2)+0.1s to Semaphore(1)+0.5s on 2026-06-06 after CI run
-        # 27068482501 saw all buurt + offshore locations hit HTTP 429.
+        # 27068482501 saw all buurt + offshore locations hit HTTP 429. The 0.5s
+        # gap is between requests only — no pre-first-request delay.
         semaphore = asyncio.Semaphore(1)
 
-        async def fetch_with_rate_limit(session: aiohttp.ClientSession, location: Dict[str, Any]):
+        async def fetch_with_rate_limit(
+            session: aiohttp.ClientSession,
+            location: Dict[str, Any],
+            delay: bool,
+        ):
             async with semaphore:
-                await asyncio.sleep(0.5)  # Inter-request gap (was 0.1, raised 2026-06-06)
+                if delay:
+                    await asyncio.sleep(0.5)  # Inter-request gap (was 0.1, raised 2026-06-06)
                 return await self._fetch_location_data(session, location)
 
         async with aiohttp.ClientSession() as session:
-            tasks = [fetch_with_rate_limit(session, loc) for loc in self.locations]
+            tasks = [
+                fetch_with_rate_limit(session, loc, delay=(i > 0))
+                for i, loc in enumerate(self.locations)
+            ]
             responses = await asyncio.gather(*tasks)
 
             for response in responses:

--- a/collectors/openmeteo_weather.py
+++ b/collectors/openmeteo_weather.py
@@ -230,16 +230,25 @@ class OpenMeteoWeatherCollector(BaseCollector):
         # 2026-06-05). At Semaphore(2) per collector that's up to 10 concurrent
         # requests, which crossed Open-Meteo's free-tier limit on 2026-06-06
         # (CI run 27068482501: every buurt + offshore location HTTP 429). Tightened
-        # to Semaphore(1) + 500 ms gap: peak ~5 concurrent, ~10 req/s headroom.
+        # to Semaphore(1) + 500 ms gap *between* requests (no gap before the first,
+        # since there's nothing to space from): peak ~5 concurrent, ~10 req/s headroom.
         semaphore = asyncio.Semaphore(1)
 
-        async def fetch_with_rate_limit(session: aiohttp.ClientSession, location: Dict[str, Any]):
+        async def fetch_with_rate_limit(
+            session: aiohttp.ClientSession,
+            location: Dict[str, Any],
+            delay: bool,
+        ):
             async with semaphore:
-                await asyncio.sleep(0.5)  # Inter-request gap (was 0.1, raised 2026-06-06)
+                if delay:
+                    await asyncio.sleep(0.5)  # Inter-request gap (was 0.1, raised 2026-06-06)
                 return await self._fetch_location_data(session, location)
 
         async with aiohttp.ClientSession() as session:
-            tasks = [fetch_with_rate_limit(session, loc) for loc in self.locations]
+            tasks = [
+                fetch_with_rate_limit(session, loc, delay=(i > 0))
+                for i, loc in enumerate(self.locations)
+            ]
             responses = await asyncio.gather(*tasks)
 
             for response in responses:

--- a/collectors/openmeteo_weather.py
+++ b/collectors/openmeteo_weather.py
@@ -224,12 +224,18 @@ class OpenMeteoWeatherCollector(BaseCollector):
         self.logger.debug(f"Fetching demand weather for {len(self.locations)} locations")
 
         results = {}
-        # Use semaphore to limit concurrent requests and avoid rate limiting (HTTP 429)
-        semaphore = asyncio.Semaphore(2)  # Max 2 concurrent (3 collectors share Open-Meteo)
+        # Use semaphore to limit concurrent requests and avoid rate limiting (HTTP 429).
+        # Five Open-Meteo collectors run concurrently in data_fetcher.py (strategic
+        # weather + solar, offshore wind, buurt weather + solar — last two added
+        # 2026-06-05). At Semaphore(2) per collector that's up to 10 concurrent
+        # requests, which crossed Open-Meteo's free-tier limit on 2026-06-06
+        # (CI run 27068482501: every buurt + offshore location HTTP 429). Tightened
+        # to Semaphore(1) + 500 ms gap: peak ~5 concurrent, ~10 req/s headroom.
+        semaphore = asyncio.Semaphore(1)
 
         async def fetch_with_rate_limit(session: aiohttp.ClientSession, location: Dict[str, Any]):
             async with semaphore:
-                await asyncio.sleep(0.1)  # Small delay between requests
+                await asyncio.sleep(0.5)  # Inter-request gap (was 0.1, raised 2026-06-06)
                 return await self._fetch_location_data(session, location)
 
         async with aiohttp.ClientSession() as session:

--- a/tests/unit/test_luchtmeetnet_cache.py
+++ b/tests/unit/test_luchtmeetnet_cache.py
@@ -405,5 +405,86 @@ class TestLuchtmeetnetCacheIntegration:
                     mock_meas.assert_called_once()
 
 
+class TestLuchtmeetnetStationFilter:
+    """Regression: stations missing lat/lon must not poison the cache.
+
+    Before 2026-06-06 a failing per-station detail-fetch (HTTP non-200 or
+    network error) left the station in `_fetch_all_stations`'s result
+    *without* `latitude`/`longitude`. `closest()` then iterated
+    `p['latitude']` over the cached list and raised `KeyError: 'latitude'`
+    for 24h — see CI run 27068482501.
+
+    These tests assert the post-fetch filter drops incomplete entries.
+    """
+
+    @pytest.mark.asyncio
+    async def test_filter_drops_stations_without_coordinates(self):
+        """Stations without lat/lon (e.g. detail-fetch HTTP 500) are dropped."""
+        LuchtmeetnetCollector._station_cache = None
+        LuchtmeetnetCollector._cache_timestamp = None
+
+        collector = LuchtmeetnetCollector(52.37, 4.89)
+
+        # First page: three stations
+        page_response = AsyncMock()
+        page_response.status = 200
+        page_response.json = AsyncMock(return_value={
+            "pagination": {"page_list": [1]},
+            "data": [
+                {"number": "NL_OK1"},
+                {"number": "NL_BAD"},
+                {"number": "NL_OK2"},
+            ],
+        })
+
+        # Per-station detail responses: NL_OK1 + NL_OK2 succeed, NL_BAD HTTP 500
+        ok1_response = AsyncMock()
+        ok1_response.status = 200
+        ok1_response.json = AsyncMock(return_value={"data": {
+            "geometry": {"type": "point", "coordinates": [4.0, 52.0]},
+            "components": [], "location": "OK1", "municipality": "Foo",
+        }})
+        bad_response = AsyncMock()
+        bad_response.status = 500
+        ok2_response = AsyncMock()
+        ok2_response.status = 200
+        ok2_response.json = AsyncMock(return_value={"data": {
+            "geometry": {"type": "Point", "coordinates": [5.0, 53.0]},  # capital P also OK
+            "components": [], "location": "OK2", "municipality": "Bar",
+        }})
+
+        responses = iter([page_response, page_response, ok1_response, bad_response, ok2_response])
+
+        def get_side_effect(url):
+            cm = AsyncMock()
+            cm.__aenter__ = AsyncMock(return_value=next(responses))
+            cm.__aexit__ = AsyncMock(return_value=None)
+            return cm
+
+        mock_session = Mock()
+        mock_session.get = Mock(side_effect=get_side_effect)
+
+        result = await collector._fetch_all_stations(mock_session)
+
+        # NL_BAD must be filtered out; only stations with coords survive.
+        numbers = [s["number"] for s in result]
+        assert "NL_BAD" not in numbers
+        assert set(numbers) == {"NL_OK1", "NL_OK2"}
+        for s in result:
+            assert "latitude" in s and "longitude" in s
+
+    @pytest.mark.asyncio
+    async def test_closest_does_not_raise_on_filtered_list(self):
+        """`closest()` over the filtered list never raises KeyError."""
+        from utils.helpers import closest
+        stations = [
+            {"number": "A", "latitude": 52.0, "longitude": 4.0},
+            {"number": "B", "latitude": 53.0, "longitude": 5.0},
+        ]
+        # Should pick A (closer to query)
+        result = closest(stations, {"latitude": 52.1, "longitude": 4.1})
+        assert result["number"] == "A"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])

--- a/tests/unit/test_luchtmeetnet_cache.py
+++ b/tests/unit/test_luchtmeetnet_cache.py
@@ -485,6 +485,69 @@ class TestLuchtmeetnetStationFilter:
         result = closest(stations, {"latitude": 52.1, "longitude": 4.1})
         assert result["number"] == "A"
 
+    @pytest.mark.asyncio
+    async def test_filter_drops_station_on_network_exception(self):
+        """A per-station detail-fetch that raises (e.g. ClientError, timeout) is dropped, not propagated.
+
+        This exercises the broad `try: ... except Exception` branch added 2026-06-06.
+        Before the guard, an aiohttp transient on one station's detail-fetch killed
+        the whole collection — that path was the *reason* for the try/except, but
+        the original regression test only covered the HTTP-non-200 path (which goes
+        through `continue`, not `except`).
+        """
+        from aiohttp import ClientConnectionError
+
+        LuchtmeetnetCollector._station_cache = None
+        LuchtmeetnetCollector._cache_timestamp = None
+
+        collector = LuchtmeetnetCollector(52.37, 4.89)
+
+        # First page response (used for both pagination discovery + page-1 fetch)
+        page_response = AsyncMock()
+        page_response.status = 200
+        page_response.json = AsyncMock(return_value={
+            "pagination": {"page_list": [1]},
+            "data": [
+                {"number": "NL_OK"},
+                {"number": "NL_NETERR"},
+            ],
+        })
+
+        ok_response = AsyncMock()
+        ok_response.status = 200
+        ok_response.json = AsyncMock(return_value={"data": {
+            "geometry": {"type": "point", "coordinates": [4.0, 52.0]},
+            "components": [], "location": "OK", "municipality": "Foo",
+        }})
+
+        call_count = [0]
+
+        def get_side_effect(url):
+            call_count[0] += 1
+            cm = AsyncMock()
+            cm.__aexit__ = AsyncMock(return_value=None)
+            if call_count[0] in (1, 2):
+                # Page-list discovery + page-1 fetch
+                cm.__aenter__ = AsyncMock(return_value=page_response)
+            elif call_count[0] == 3:
+                # NL_OK detail
+                cm.__aenter__ = AsyncMock(return_value=ok_response)
+            else:
+                # NL_NETERR detail — network error on context-manager entry
+                cm.__aenter__ = AsyncMock(side_effect=ClientConnectionError("connection reset"))
+            return cm
+
+        mock_session = Mock()
+        mock_session.get = Mock(side_effect=get_side_effect)
+
+        # Must NOT raise — the try/except in _fetch_all_stations catches it,
+        # the filter drops the un-coord'd station, and the good station comes back.
+        result = await collector._fetch_all_stations(mock_session)
+
+        numbers = [s["number"] for s in result]
+        assert "NL_NETERR" not in numbers
+        assert numbers == ["NL_OK"]
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
## Why

The 2026-06-06 17:03 UTC scheduled run failed at the new data-quality gate — `weather_forecast_buurt` and `solar_forecast_buurt` both flagged `critical` with `actual=0, expected_min=24`. The gate (added 2026-06-05) did its job: nothing got published with empty data. CI run [27068482501](https://github.com/ducroq/energydatahub/actions/runs/27068482501).

Three distinct bugs surfaced.

## What

### 1. Open-Meteo HTTP 429 (rate-limit)
The per-collector `Semaphore(2)` + 0.1 s sleep was sized for *3 collectors share Open-Meteo* (per the stale comment). After 2026-06-05 there are now **5**: strategic weather, strategic solar, offshore wind, **buurt weather**, **buurt solar**. Peak concurrency hit ~10; every buurt + offshore location returned 429.

Tightened all three collectors to `Semaphore(1)` + 0.5 s gap → peak ~5 concurrent, ~10 req/s headroom.

### 2. Luchtmeetnet `KeyError: 'latitude'`
Real underlying bug, not buurt-specific. In `_fetch_all_stations`, a station whose detail-fetch failed (HTTP non-200 or network exception) stayed in the returned list **without** `latitude`/`longitude`. The 24 h station cache then carried the broken entry. `closest()` iterates `p['latitude']` over every member and crashes the whole collector — for any `LuchtmeetnetCollector` instance, for 24 h.

Fix:
- wrap per-station detail-fetch in `try/except` so one failure can't abort the loop
- filter out stations without coords before returning (and log the count)
- accept both `'point'` (current) and `'Point'` (RFC 7946 GeoJSON standard) — defensive against a future upstream spec-fix

### 3. Stale comment
The misleading *"3 collectors share Open-Meteo"* comment is what kept the `Semaphore(2)` plausible-looking after the 2026-06-05 buurt additions. Updated in all three Open-Meteo files.

## Tests

- 16/16 in `tests/unit/test_luchtmeetnet_cache.py` pass (14 existing + 2 new regression tests in `TestLuchtmeetnetStationFilter`).
- No Open-Meteo unit tests exist; the semaphore/sleep changes are literal-value edits.

## Out of scope (separate fixes)

- TenneT 422 → 429 cascade (recurring)
- `ned_production` completeness 6/24
- `gas_storage` value_range + staleness (unit-mix)

## Downstream

FyE side is already wired (`scripts/harvest_buurt_macro.py`); once this merges and the next scheduled run publishes `solar_forecast_buurt.json` + `air_quality_buurt.json` cleanly, FyE picks them up with no further changes.