### PR TITLE
harden Luchtmeetnet: quality signal, no empty-cache, narrow except (#12 #13 #14)

### DIFF
--- a/collectors/luchtmeetnet.py
+++ b/collectors/luchtmeetnet.py
@@ -26,6 +26,7 @@ Usage:
 """
 
 import asyncio
+import json
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 import aiohttp
@@ -33,6 +34,15 @@ import aiohttp
 from collectors.base import BaseCollector, RetryConfig
 from utils.timezone_helpers import normalize_timestamp_to_amsterdam
 from utils.helpers import closest
+
+
+# Station-completeness thresholds for the data-quality signal emitted in
+# `_get_metadata`. 0–25% filtered = transient upstream noise (no issue);
+# 25–50% = warning (broad degradation); >50% = critical (the bbox may no
+# longer have a sane closest station — the workflow gate will block publish).
+# See issue #12.
+STATION_FILTER_WARN_THRESHOLD = 0.25
+STATION_FILTER_CRITICAL_THRESHOLD = 0.50
 
 
 class LuchtmeetnetCollector(BaseCollector):
@@ -50,6 +60,10 @@ class LuchtmeetnetCollector(BaseCollector):
     _station_cache: Optional[List[Dict]] = None
     _cache_timestamp: Optional[datetime] = None
     _cache_duration = timedelta(hours=24)  # Cache for 24 hours
+    # Filter stats from the most recent `_fetch_all_stations` call, kept on
+    # the class so cache hits inherit the snapshot they were taken from.
+    # Shape: {'total': int, 'filtered': int}
+    _cache_filter_stats: Optional[Dict[str, int]] = None
 
     def __init__(
         self,
@@ -166,10 +180,19 @@ class LuchtmeetnetCollector(BaseCollector):
         self.logger.info("Station cache miss or expired, fetching fresh data")
         stations = await self._fetch_all_stations(session)
 
-        # Update cache
-        LuchtmeetnetCollector._station_cache = stations
-        LuchtmeetnetCollector._cache_timestamp = now
-        self.logger.info(f"Cached {len(stations)} stations")
+        # Refuse to cache empty results — a one-off upstream outage would
+        # otherwise lock collection out for 24h (issue #13). The caller's
+        # existing `if not stations` check will fail this run; the next run
+        # gets a fresh retry instead of inheriting a poisoned cache.
+        if stations:
+            LuchtmeetnetCollector._station_cache = stations
+            LuchtmeetnetCollector._cache_timestamp = now
+            self.logger.info(f"Cached {len(stations)} stations")
+        else:
+            self.logger.warning(
+                "Refusing to cache empty station list — upstream likely "
+                "degraded; next run will retry"
+            )
 
         return stations
 
@@ -221,12 +244,21 @@ class LuchtmeetnetCollector(BaseCollector):
                         station['components'] = station_data.get('components', [])
                         station['location'] = station_data.get('location', '')
                         station['municipality'] = station_data.get('municipality', '')
-            except Exception as e:
+            except (
+                aiohttp.ClientError,
+                asyncio.TimeoutError,
+                json.JSONDecodeError,
+                ValueError,
+                KeyError,
+                TypeError,
+            ) as e:
                 # Single-station network/parse failures must not poison the cache.
                 # Before this guard a single bad detail-fetch left the station in
                 # the list without lat/lon, causing the cached list to crash
                 # `closest()` with KeyError: 'latitude' for 24h (see CI run
-                # 27068482501, 2026-06-06).
+                # 27068482501, 2026-06-06). The except list is narrow on purpose:
+                # AttributeError / NameError from a future refactor mistake should
+                # propagate so the bug surfaces immediately (issue #14).
                 self.logger.warning(
                     f"Skipping station {station.get('number', '?')}: detail-fetch failed ({e})"
                 )
@@ -235,11 +267,17 @@ class LuchtmeetnetCollector(BaseCollector):
         # iterates p['latitude'] over every member; a single missing entry
         # raises KeyError and kills the whole collection.
         clean = [s for s in station_list if 'latitude' in s and 'longitude' in s]
-        if len(clean) < len(station_list):
+        filtered = len(station_list) - len(clean)
+        if filtered:
             self.logger.info(
-                f"Filtered {len(station_list) - len(clean)} stations without coordinates "
+                f"Filtered {filtered} stations without coordinates "
                 f"({len(clean)}/{len(station_list)} usable)"
             )
+        # Snapshot for the data-quality signal emitted in _get_metadata (#12).
+        LuchtmeetnetCollector._cache_filter_stats = {
+            'total': len(station_list),
+            'filtered': filtered,
+        }
         return clean
 
     async def _fetch_aqi(
@@ -384,6 +422,35 @@ class LuchtmeetnetCollector(BaseCollector):
             'requested_longitude': self.longitude,
             'units': {'all': 'µg/m³'}
         })
+
+        # Surface station-completeness as a data-quality signal so the
+        # workflow's `data_quality_report.overall_status == critical` gate
+        # can block publish when station selection is broadly degraded
+        # (issue #12). Stats are taken from the most recent _fetch_all_stations
+        # call; on cache hits the same snapshot is reused.
+        stats = LuchtmeetnetCollector._cache_filter_stats
+        if stats and stats['total'] > 0:
+            filtered = stats['filtered']
+            total = stats['total']
+            ratio = filtered / total
+            metadata['stations_total'] = total
+            metadata['stations_filtered'] = filtered
+            metadata['stations_filtered_pct'] = round(ratio * 100, 1)
+            if ratio > STATION_FILTER_WARN_THRESHOLD:
+                severity = (
+                    'critical' if ratio > STATION_FILTER_CRITICAL_THRESHOLD
+                    else 'warning'
+                )
+                metadata.setdefault('collector_quality_issues', []).append({
+                    'check_name': 'station_completeness',
+                    'severity': severity,
+                    'message': (
+                        f"{filtered}/{total} Luchtmeetnet stations filtered "
+                        f"({ratio * 100:.0f}%) — selection may have shifted "
+                        f"to a less-representative station"
+                    ),
+                    'details': {'filtered': filtered, 'total': total},
+                })
 
         return metadata
 

--- a/collectors/luchtmeetnet.py
+++ b/collectors/luchtmeetnet.py
@@ -27,6 +27,7 @@ Usage:
 
 import asyncio
 import json
+import re
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 import aiohttp
@@ -44,6 +45,13 @@ from utils.helpers import closest
 STATION_FILTER_WARN_THRESHOLD = 0.25
 STATION_FILTER_CRITICAL_THRESHOLD = 0.50
 
+# Strict allowlist for station identifiers before they're interpolated into
+# URLs or log messages. RIVM IDs are short alphanumerics (e.g. "NL10497");
+# underscores/hyphens accepted because they're URL-safe and used in some
+# legacy/test identifiers. Rejects newlines (log-injection vector), path-
+# traversal segments, and quoting characters. See security audit on PR #16.
+_STATION_NUMBER_PATTERN = re.compile(r'^[A-Za-z0-9_-]{1,32}$')
+
 
 class LuchtmeetnetCollector(BaseCollector):
     """
@@ -60,9 +68,11 @@ class LuchtmeetnetCollector(BaseCollector):
     _station_cache: Optional[List[Dict]] = None
     _cache_timestamp: Optional[datetime] = None
     _cache_duration = timedelta(hours=24)  # Cache for 24 hours
-    # Filter stats from the most recent `_fetch_all_stations` call, kept on
-    # the class so cache hits inherit the snapshot they were taken from.
-    # Shape: {'total': int, 'filtered': int}
+    # Most-recent filter-stats snapshot taken when the cache was written.
+    # Used only to seed `self._last_filter_stats` on cache hits — the
+    # per-fetch stats themselves live on the INSTANCE so concurrent buurt
+    # collectors can never see each other's stats misattributed (security
+    # audit HIGH-1 on PR #16).
     _cache_filter_stats: Optional[Dict[str, int]] = None
 
     def __init__(
@@ -90,6 +100,10 @@ class LuchtmeetnetCollector(BaseCollector):
         self.longitude = longitude
         self.base_url = 'https://api.luchtmeetnet.nl/open_api'
         self.closest_station = None  # Cache closest station
+        # Per-instance filter stats from this collector's most recent station
+        # fetch (or copied from class snapshot on cache hit). Instance-scoped
+        # so concurrent buurt collectors can't overwrite each other.
+        self._last_filter_stats: Optional[Dict[str, int]] = None
 
     async def _fetch_raw_data(
         self,
@@ -174,6 +188,9 @@ class LuchtmeetnetCollector(BaseCollector):
                 self.logger.info(
                     f"Using cached station list (age: {cache_age.total_seconds()/3600:.1f}h)"
                 )
+                # Inherit the snapshot's stats so _get_metadata can emit
+                # the station_completeness signal even on cache hits.
+                self._last_filter_stats = LuchtmeetnetCollector._cache_filter_stats
                 return LuchtmeetnetCollector._station_cache
 
         # Cache miss or expired - fetch new data
@@ -186,6 +203,7 @@ class LuchtmeetnetCollector(BaseCollector):
         # gets a fresh retry instead of inheriting a poisoned cache.
         if stations:
             LuchtmeetnetCollector._station_cache = stations
+            LuchtmeetnetCollector._cache_filter_stats = self._last_filter_stats
             LuchtmeetnetCollector._cache_timestamp = now
             self.logger.info(f"Cached {len(stations)} stations")
         else:
@@ -224,7 +242,17 @@ class LuchtmeetnetCollector(BaseCollector):
 
         # Fetch details for each station
         for station in station_list:
-            url = f"{self.base_url}/stations/{station['number']}/"
+            # Reject station numbers that don't match the expected pattern
+            # before interpolating them into URLs or log messages — defends
+            # against log-injection (newlines in number) and path-traversal
+            # in the URL segment (security audit MEDIUM-2 on PR #16).
+            raw_number = station.get('number')
+            if not isinstance(raw_number, str) or not _STATION_NUMBER_PATTERN.match(raw_number):
+                self.logger.warning(
+                    f"Skipping station with malformed number (len={len(raw_number) if isinstance(raw_number, str) else 'n/a'})"
+                )
+                continue
+            url = f"{self.base_url}/stations/{raw_number}/"
             try:
                 async with session.get(url) as response:
                     if response.status != 200:
@@ -255,12 +283,12 @@ class LuchtmeetnetCollector(BaseCollector):
                 # Single-station network/parse failures must not poison the cache.
                 # Before this guard a single bad detail-fetch left the station in
                 # the list without lat/lon, causing the cached list to crash
-                # `closest()` with KeyError: 'latitude' for 24h (see CI run
-                # 27068482501, 2026-06-06). The except list is narrow on purpose:
-                # AttributeError / NameError from a future refactor mistake should
-                # propagate so the bug surfaces immediately (issue #14).
+                # `closest()` for 24h (issue #14). Except list is narrow on
+                # purpose: AttributeError/NameError from a future refactor
+                # mistake should propagate. `raw_number` is pre-validated above
+                # so it's safe to interpolate into the log.
                 self.logger.warning(
-                    f"Skipping station {station.get('number', '?')}: detail-fetch failed ({e})"
+                    f"Skipping station {raw_number}: detail-fetch failed ({type(e).__name__})"
                 )
 
         # Drop any station that didn't get coordinates assigned. `closest()`
@@ -273,8 +301,11 @@ class LuchtmeetnetCollector(BaseCollector):
                 f"Filtered {filtered} stations without coordinates "
                 f"({len(clean)}/{len(station_list)} usable)"
             )
-        # Snapshot for the data-quality signal emitted in _get_metadata (#12).
-        LuchtmeetnetCollector._cache_filter_stats = {
+        # INSTANCE-scoped stats — concurrent buurt collectors cannot overwrite
+        # each other's snapshot (security audit HIGH-1 on PR #16). The class-
+        # level _cache_filter_stats slot is updated in _get_stations_cached
+        # alongside _station_cache so cache hits can inherit.
+        self._last_filter_stats = {
             'total': len(station_list),
             'filtered': filtered,
         }
@@ -426,9 +457,11 @@ class LuchtmeetnetCollector(BaseCollector):
         # Surface station-completeness as a data-quality signal so the
         # workflow's `data_quality_report.overall_status == critical` gate
         # can block publish when station selection is broadly degraded
-        # (issue #12). Stats are taken from the most recent _fetch_all_stations
-        # call; on cache hits the same snapshot is reused.
-        stats = LuchtmeetnetCollector._cache_filter_stats
+        # (issue #12). Stats come from this instance's most recent fetch,
+        # or were copied from the class snapshot on a cache hit. Reading
+        # from instance state means concurrent buurt collectors cannot
+        # misattribute each other's stats (security audit HIGH-1).
+        stats = self._last_filter_stats
         if stats and stats['total'] > 0:
             filtered = stats['filtered']
             total = stats['total']

--- a/tests/unit/test_luchtmeetnet_cache.py
+++ b/tests/unit/test_luchtmeetnet_cache.py
@@ -301,25 +301,60 @@ class TestLuchtmeetnetCacheEdgeCases:
     """Test edge cases and error conditions."""
 
     @pytest.mark.asyncio
-    async def test_empty_station_list_cached(self):
-        """Empty station list should still be cached."""
+    async def test_empty_station_list_not_cached(self):
+        """Empty station list must NOT be cached (issue #13).
+
+        Caching an empty list would lock collection out for the full 24h
+        TTL — the caller's `if not stations: raise ValueError` check would
+        fire every run until the cache expires. Inverted from the original
+        `test_empty_station_list_cached` which documented the bug as
+        intended behavior.
+        """
         LuchtmeetnetCollector._station_cache = None
         LuchtmeetnetCollector._cache_timestamp = None
 
         collector = LuchtmeetnetCollector(52.37, 4.89)
 
-        empty_stations = []
-
         with patch.object(collector, '_fetch_all_stations', new_callable=AsyncMock) as mock_fetch:
-            mock_fetch.return_value = empty_stations
+            mock_fetch.return_value = []
             mock_session = AsyncMock()
 
             stations = await collector._get_stations_cached(mock_session)
 
-            # Empty list should be cached
-            assert LuchtmeetnetCollector._station_cache == []
-            assert LuchtmeetnetCollector._cache_timestamp is not None
+            # Empty result is returned (caller will raise) but NOT persisted.
             assert stations == []
+            assert LuchtmeetnetCollector._station_cache is None
+            assert LuchtmeetnetCollector._cache_timestamp is None
+
+    @pytest.mark.asyncio
+    async def test_empty_fetch_does_not_overwrite_existing_cache(self):
+        """A subsequent empty fetch must not wipe a previously-good cache (#13).
+
+        Scenario: yesterday's run cached a healthy station list, the cache
+        has now expired, today's fetch returns empty (upstream outage).
+        Before the fix the empty list overwrote the cached good list. After
+        the fix the cache slot is preserved so a third call within the
+        original 24h window could still hit a sane snapshot.
+        """
+        good_stations = [
+            {'number': 'NL001', 'latitude': 52.37, 'longitude': 4.89}
+        ]
+        LuchtmeetnetCollector._station_cache = good_stations
+        original_ts = datetime.now() - timedelta(hours=25)  # expired
+        LuchtmeetnetCollector._cache_timestamp = original_ts
+
+        collector = LuchtmeetnetCollector(52.37, 4.89)
+
+        with patch.object(collector, '_fetch_all_stations', new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = []
+            mock_session = AsyncMock()
+
+            result = await collector._get_stations_cached(mock_session)
+
+            # Empty result is returned, but the previously-good cache stays put.
+            assert result == []
+            assert LuchtmeetnetCollector._station_cache == good_stations
+            assert LuchtmeetnetCollector._cache_timestamp == original_ts
 
     @pytest.mark.asyncio
     async def test_none_timestamp_triggers_fetch(self):
@@ -547,6 +582,211 @@ class TestLuchtmeetnetStationFilter:
         numbers = [s["number"] for s in result]
         assert "NL_NETERR" not in numbers
         assert numbers == ["NL_OK"]
+
+
+class TestLuchtmeetnetNarrowExcept:
+    """Issue #14: per-station detail-fetch must only swallow realistic
+    upstream-failure modes (aiohttp / asyncio.timeout / JSON / Key / Type /
+    Value). Programmer errors like AttributeError must propagate so future
+    refactor mistakes surface immediately rather than vanishing into the
+    'station was filtered' path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_attribute_error_propagates_through_narrow_except(self):
+        """AttributeError from inside the loop body is NOT swallowed."""
+        LuchtmeetnetCollector._station_cache = None
+        LuchtmeetnetCollector._cache_timestamp = None
+
+        collector = LuchtmeetnetCollector(52.37, 4.89)
+
+        page_response = AsyncMock()
+        page_response.status = 200
+        page_response.json = AsyncMock(return_value={
+            "pagination": {"page_list": [1]},
+            "data": [{"number": "NL_ATTR"}],
+        })
+
+        # Detail-fetch returns a response whose .json() coroutine raises
+        # AttributeError. That's the shape a real programmer error (e.g.
+        # `data.dat['x']` typo) would take, and the narrow except clause
+        # must not catch it.
+        bad_detail = AsyncMock()
+        bad_detail.status = 200
+        bad_detail.json = AsyncMock(side_effect=AttributeError("simulated typo"))
+
+        responses = iter([page_response, page_response, bad_detail])
+
+        def get_side_effect(url):
+            cm = AsyncMock()
+            cm.__aenter__ = AsyncMock(return_value=next(responses))
+            cm.__aexit__ = AsyncMock(return_value=None)
+            return cm
+
+        mock_session = Mock()
+        mock_session.get = Mock(side_effect=get_side_effect)
+
+        with pytest.raises(AttributeError, match="simulated typo"):
+            await collector._fetch_all_stations(mock_session)
+
+
+class TestLuchtmeetnetStationCompletenessQuality:
+    """Issue #12: when >N% of stations are filtered, the collector must
+    emit a `station_completeness` quality issue in metadata so the
+    workflow's data_quality_report gate can act on it.
+    """
+
+    def _reset_class_state(self):
+        LuchtmeetnetCollector._station_cache = None
+        LuchtmeetnetCollector._cache_timestamp = None
+        LuchtmeetnetCollector._cache_filter_stats = None
+
+    def test_no_issue_when_no_stations_filtered(self):
+        """0% filtered → no quality issue (clean upstream)."""
+        self._reset_class_state()
+        LuchtmeetnetCollector._cache_filter_stats = {'total': 100, 'filtered': 0}
+
+        collector = LuchtmeetnetCollector(52.37, 4.89)
+        start = datetime.now()
+        end = start + timedelta(hours=1)
+        metadata = collector._get_metadata(start, end)
+
+        assert metadata['stations_filtered'] == 0
+        assert metadata['stations_filtered_pct'] == 0.0
+        assert 'collector_quality_issues' not in metadata
+
+    def test_no_issue_below_warning_threshold(self):
+        """20% filtered → still below 25% threshold → no issue."""
+        self._reset_class_state()
+        LuchtmeetnetCollector._cache_filter_stats = {'total': 100, 'filtered': 20}
+
+        collector = LuchtmeetnetCollector(52.37, 4.89)
+        start = datetime.now()
+        end = start + timedelta(hours=1)
+        metadata = collector._get_metadata(start, end)
+
+        assert metadata['stations_filtered_pct'] == 20.0
+        assert 'collector_quality_issues' not in metadata
+
+    def test_warning_issue_above_warning_threshold(self):
+        """30% filtered → warning severity."""
+        self._reset_class_state()
+        LuchtmeetnetCollector._cache_filter_stats = {'total': 100, 'filtered': 30}
+
+        collector = LuchtmeetnetCollector(52.37, 4.89)
+        start = datetime.now()
+        end = start + timedelta(hours=1)
+        metadata = collector._get_metadata(start, end)
+
+        issues = metadata.get('collector_quality_issues', [])
+        assert len(issues) == 1
+        assert issues[0]['check_name'] == 'station_completeness'
+        assert issues[0]['severity'] == 'warning'
+        assert issues[0]['details'] == {'filtered': 30, 'total': 100}
+
+    def test_critical_issue_above_critical_threshold(self):
+        """60% filtered → critical severity (workflow gate aborts publish)."""
+        self._reset_class_state()
+        LuchtmeetnetCollector._cache_filter_stats = {'total': 100, 'filtered': 60}
+
+        collector = LuchtmeetnetCollector(52.37, 4.89)
+        start = datetime.now()
+        end = start + timedelta(hours=1)
+        metadata = collector._get_metadata(start, end)
+
+        issues = metadata.get('collector_quality_issues', [])
+        assert len(issues) == 1
+        assert issues[0]['severity'] == 'critical'
+
+    @pytest.mark.asyncio
+    async def test_filter_stats_populated_after_fetch(self):
+        """_fetch_all_stations must populate _cache_filter_stats."""
+        self._reset_class_state()
+
+        collector = LuchtmeetnetCollector(52.37, 4.89)
+
+        page_response = AsyncMock()
+        page_response.status = 200
+        page_response.json = AsyncMock(return_value={
+            "pagination": {"page_list": [1]},
+            "data": [{"number": "OK1"}, {"number": "BAD"}, {"number": "OK2"}],
+        })
+        ok_response = AsyncMock()
+        ok_response.status = 200
+        ok_response.json = AsyncMock(return_value={"data": {
+            "geometry": {"type": "point", "coordinates": [4.0, 52.0]},
+            "components": [], "location": "ok", "municipality": "x",
+        }})
+        bad_response = AsyncMock()
+        bad_response.status = 500
+
+        responses = iter([
+            page_response, page_response,  # page-list discovery + page-1 fetch
+            ok_response, bad_response, ok_response,  # 3 detail fetches
+        ])
+
+        def get_side_effect(url):
+            cm = AsyncMock()
+            cm.__aenter__ = AsyncMock(return_value=next(responses))
+            cm.__aexit__ = AsyncMock(return_value=None)
+            return cm
+
+        mock_session = Mock()
+        mock_session.get = Mock(side_effect=get_side_effect)
+
+        await collector._fetch_all_stations(mock_session)
+
+        assert LuchtmeetnetCollector._cache_filter_stats == {
+            'total': 3, 'filtered': 1
+        }
+
+
+class TestDataQualityCollectorIssuesIntegration:
+    """data_quality.validate_dataset must surface collector_quality_issues
+    from metadata into the per-dataset QualityIssue list (#12 plumbing).
+    """
+
+    def test_collector_critical_issue_flips_dataset_status(self):
+        from utils.data_quality import validate_dataset, Severity
+        from utils.data_types import EnhancedDataSet
+        from zoneinfo import ZoneInfo
+
+        ams = ZoneInfo('Europe/Amsterdam')
+        now = datetime.now(ams)
+
+        # Minimal dataset with a critical collector-emitted issue.
+        dataset = EnhancedDataSet(
+            metadata={
+                'data_type': 'air',
+                'source': 'Luchtmeetnet API',
+                'units': 'µg/m³',
+                'start_time': now.isoformat(),
+                'end_time': now.isoformat(),
+                'collector': 'LuchtmeetnetCollector',
+                'collector_quality_issues': [{
+                    'check_name': 'station_completeness',
+                    'severity': 'critical',
+                    'message': '60/100 stations filtered (60%)',
+                    'details': {'filtered': 60, 'total': 100},
+                }],
+            },
+            # Enough data points to satisfy the completeness/staleness checks
+            # so we know `critical` came from the collector issue, not them.
+            data={
+                (now - timedelta(hours=i)).isoformat(): {'NO2': 20.0}
+                for i in range(24)
+            },
+        )
+
+        report = validate_dataset(dataset, 'air_quality_buurt')
+
+        station_issues = [
+            i for i in report.issues if i.check_name == 'station_completeness'
+        ]
+        assert len(station_issues) == 1
+        assert station_issues[0].severity == Severity.CRITICAL
+        # Status should be critical (this is what the workflow gate checks)
+        assert report.status == 'critical'
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_luchtmeetnet_cache.py
+++ b/tests/unit/test_luchtmeetnet_cache.py
@@ -644,9 +644,9 @@ class TestLuchtmeetnetStationCompletenessQuality:
     def test_no_issue_when_no_stations_filtered(self):
         """0% filtered → no quality issue (clean upstream)."""
         self._reset_class_state()
-        LuchtmeetnetCollector._cache_filter_stats = {'total': 100, 'filtered': 0}
 
         collector = LuchtmeetnetCollector(52.37, 4.89)
+        collector._last_filter_stats = {'total': 100, 'filtered': 0}
         start = datetime.now()
         end = start + timedelta(hours=1)
         metadata = collector._get_metadata(start, end)
@@ -658,9 +658,9 @@ class TestLuchtmeetnetStationCompletenessQuality:
     def test_no_issue_below_warning_threshold(self):
         """20% filtered → still below 25% threshold → no issue."""
         self._reset_class_state()
-        LuchtmeetnetCollector._cache_filter_stats = {'total': 100, 'filtered': 20}
 
         collector = LuchtmeetnetCollector(52.37, 4.89)
+        collector._last_filter_stats = {'total': 100, 'filtered': 20}
         start = datetime.now()
         end = start + timedelta(hours=1)
         metadata = collector._get_metadata(start, end)
@@ -671,9 +671,9 @@ class TestLuchtmeetnetStationCompletenessQuality:
     def test_warning_issue_above_warning_threshold(self):
         """30% filtered → warning severity."""
         self._reset_class_state()
-        LuchtmeetnetCollector._cache_filter_stats = {'total': 100, 'filtered': 30}
 
         collector = LuchtmeetnetCollector(52.37, 4.89)
+        collector._last_filter_stats = {'total': 100, 'filtered': 30}
         start = datetime.now()
         end = start + timedelta(hours=1)
         metadata = collector._get_metadata(start, end)
@@ -687,9 +687,9 @@ class TestLuchtmeetnetStationCompletenessQuality:
     def test_critical_issue_above_critical_threshold(self):
         """60% filtered → critical severity (workflow gate aborts publish)."""
         self._reset_class_state()
-        LuchtmeetnetCollector._cache_filter_stats = {'total': 100, 'filtered': 60}
 
         collector = LuchtmeetnetCollector(52.37, 4.89)
+        collector._last_filter_stats = {'total': 100, 'filtered': 60}
         start = datetime.now()
         end = start + timedelta(hours=1)
         metadata = collector._get_metadata(start, end)
@@ -699,8 +699,9 @@ class TestLuchtmeetnetStationCompletenessQuality:
         assert issues[0]['severity'] == 'critical'
 
     @pytest.mark.asyncio
-    async def test_filter_stats_populated_after_fetch(self):
-        """_fetch_all_stations must populate _cache_filter_stats."""
+    async def test_filter_stats_populated_on_instance_after_fetch(self):
+        """_fetch_all_stations must populate self._last_filter_stats (INSTANCE-
+        scoped per the PR #16 review HIGH-1 fix)."""
         self._reset_class_state()
 
         collector = LuchtmeetnetCollector(52.37, 4.89)
@@ -736,9 +737,31 @@ class TestLuchtmeetnetStationCompletenessQuality:
 
         await collector._fetch_all_stations(mock_session)
 
-        assert LuchtmeetnetCollector._cache_filter_stats == {
-            'total': 3, 'filtered': 1
-        }
+        assert collector._last_filter_stats == {'total': 3, 'filtered': 1}
+
+    def test_concurrent_collectors_do_not_share_filter_stats(self):
+        """HIGH-1 regression: two concurrent buurt collectors must have
+        independent `_last_filter_stats`. Before the fix this was a
+        class-level slot — one buurt's stats could overwrite another's
+        between fetch and `_get_metadata`, misattributing the
+        station_completeness signal to the wrong buurt.
+        """
+        self._reset_class_state()
+
+        c1 = LuchtmeetnetCollector(52.37, 4.89)
+        c2 = LuchtmeetnetCollector(51.99, 5.90)
+
+        c1._last_filter_stats = {'total': 100, 'filtered': 60}  # critical
+        c2._last_filter_stats = {'total': 100, 'filtered': 5}   # clean
+
+        m1 = c1._get_metadata(datetime.now(), datetime.now() + timedelta(hours=1))
+        m2 = c2._get_metadata(datetime.now(), datetime.now() + timedelta(hours=1))
+
+        # c1 emits critical, c2 emits no issue — neither sees the other's stats.
+        assert m1['collector_quality_issues'][0]['severity'] == 'critical'
+        assert 'collector_quality_issues' not in m2
+        assert m1['stations_filtered'] == 60
+        assert m2['stations_filtered'] == 5
 
 
 class TestDataQualityCollectorIssuesIntegration:
@@ -787,6 +810,134 @@ class TestDataQualityCollectorIssuesIntegration:
         assert station_issues[0].severity == Severity.CRITICAL
         # Status should be critical (this is what the workflow gate checks)
         assert report.status == 'critical'
+
+    def test_info_severity_does_not_inflate_checks_failed(self):
+        """PR #16 review MEDIUM-1: INFO-severity collector issues are
+        informational only and must NOT increment `checks_failed`.
+        """
+        from utils.data_quality import validate_dataset
+        from utils.data_types import EnhancedDataSet
+        from zoneinfo import ZoneInfo
+
+        now = datetime.now(ZoneInfo('Europe/Amsterdam'))
+        dataset = EnhancedDataSet(
+            metadata={
+                'data_type': 'air',
+                'source': 'Luchtmeetnet API',
+                'units': 'µg/m³',
+                'collector': 'LuchtmeetnetCollector',
+                'collector_quality_issues': [{
+                    'check_name': 'station_completeness',
+                    'severity': 'info',
+                    'message': 'station selection nominal',
+                    'details': {'filtered': 1, 'total': 100},
+                }],
+            },
+            data={
+                (now - timedelta(hours=i)).isoformat(): {'NO2': 20.0}
+                for i in range(24)
+            },
+        )
+
+        report = validate_dataset(dataset, 'air_quality_buurt')
+
+        # The info issue is recorded but not counted as a failed check.
+        info_issues = [i for i in report.issues if i.severity.value == 'info']
+        assert len(info_issues) == 1
+        # checks_failed should reflect only ≥WARNING issues. Generic checks
+        # all pass on this dataset, so checks_failed must be 0.
+        assert report.checks_failed == 0
+        # Status stays at the lowest severity (info → 'info').
+        assert report.status == 'info'
+
+    def test_unknown_severity_downgrades_to_warning_and_counts(self):
+        """Malformed severity string → conservative WARNING + counted as
+        failed (so the bad emission doesn't silently look benign)."""
+        from utils.data_quality import validate_dataset, Severity
+        from utils.data_types import EnhancedDataSet
+        from zoneinfo import ZoneInfo
+
+        now = datetime.now(ZoneInfo('Europe/Amsterdam'))
+        dataset = EnhancedDataSet(
+            metadata={
+                'data_type': 'air',
+                'source': 'Luchtmeetnet API',
+                'units': 'µg/m³',
+                'collector': 'LuchtmeetnetCollector',
+                'collector_quality_issues': [{
+                    'check_name': 'mystery',
+                    'severity': 'NOT_A_REAL_LEVEL',
+                    'message': 'malformed emission',
+                }],
+            },
+            data={
+                (now - timedelta(hours=i)).isoformat(): {'NO2': 20.0}
+                for i in range(24)
+            },
+        )
+
+        report = validate_dataset(dataset, 'air_quality_buurt')
+
+        mystery = [i for i in report.issues if i.check_name == 'mystery']
+        assert len(mystery) == 1
+        assert mystery[0].severity == Severity.WARNING
+        assert report.checks_failed >= 1
+
+
+class TestLuchtmeetnetStationNumberValidation:
+    """PR #16 security audit MEDIUM-2: station['number'] from upstream is
+    interpolated into URLs and log messages. Without validation, an attacker
+    controlling the upstream API can inject newlines (log injection) or
+    path-traversal segments.
+    """
+
+    @pytest.mark.asyncio
+    async def test_malformed_station_number_with_newline_is_skipped(self):
+        """A station number containing a newline (log injection) is skipped
+        without ever appearing in a log or URL."""
+        LuchtmeetnetCollector._station_cache = None
+        LuchtmeetnetCollector._cache_timestamp = None
+
+        collector = LuchtmeetnetCollector(52.37, 4.89)
+
+        page_response = AsyncMock()
+        page_response.status = 200
+        page_response.json = AsyncMock(return_value={
+            "pagination": {"page_list": [1]},
+            "data": [
+                {"number": "NL001"},                           # valid
+                {"number": "NL\n[ERROR] injected fake log"},   # log-injection
+                {"number": "../etc/passwd"},                   # path-traversal
+                {"number": ""},                                # empty
+                {"number": 12345},                             # wrong type
+            ],
+        })
+        ok_response = AsyncMock()
+        ok_response.status = 200
+        ok_response.json = AsyncMock(return_value={"data": {
+            "geometry": {"type": "point", "coordinates": [4.0, 52.0]},
+            "components": [], "location": "ok", "municipality": "x",
+        }})
+
+        # Only valid NL001 should reach the detail-fetch.
+        responses = iter([page_response, page_response, ok_response])
+
+        def get_side_effect(url):
+            # URL must never contain raw injected content.
+            assert '\n' not in url
+            assert '..' not in url
+            cm = AsyncMock()
+            cm.__aenter__ = AsyncMock(return_value=next(responses))
+            cm.__aexit__ = AsyncMock(return_value=None)
+            return cm
+
+        mock_session = Mock()
+        mock_session.get = Mock(side_effect=get_side_effect)
+
+        result = await collector._fetch_all_stations(mock_session)
+
+        numbers = [s.get("number") for s in result]
+        assert numbers == ["NL001"]
 
 
 if __name__ == "__main__":

--- a/utils/data_quality.py
+++ b/utils/data_quality.py
@@ -745,11 +745,17 @@ def validate_dataset(
     # same pipeline-level gate as the generic checks above.
     for issue_dict in dataset.metadata.get('collector_quality_issues', []) or []:
         checks_run += 1
-        checks_failed += 1
         try:
             severity = Severity(issue_dict['severity'])
         except (KeyError, ValueError):
+            # Unknown / missing severity → conservative downgrade to WARNING
+            # so a malformed collector emission doesn't silently look benign.
             severity = Severity.WARNING
+        # Only count toward checks_failed when severity warrants attention.
+        # INFO-severity collector signals are informational only and must
+        # not inflate the failed-checks count (PR #16 review MEDIUM-1).
+        if severity in (Severity.WARNING, Severity.ERROR, Severity.CRITICAL):
+            checks_failed += 1
         report.issues.append(QualityIssue(
             check_name=issue_dict.get('check_name', 'collector_issue'),
             severity=severity,

--- a/utils/data_quality.py
+++ b/utils/data_quality.py
@@ -739,6 +739,24 @@ def validate_dataset(
         checks_failed += 1
         report.issues.extend(dup_issues)
 
+    # 6. Collector-emitted quality issues — surface anything the collector
+    # itself flagged in metadata['collector_quality_issues'] so domain-specific
+    # signals (e.g. Luchtmeetnet station_completeness, issue #12) flow into the
+    # same pipeline-level gate as the generic checks above.
+    for issue_dict in dataset.metadata.get('collector_quality_issues', []) or []:
+        checks_run += 1
+        checks_failed += 1
+        try:
+            severity = Severity(issue_dict['severity'])
+        except (KeyError, ValueError):
+            severity = Severity.WARNING
+        report.issues.append(QualityIssue(
+            check_name=issue_dict.get('check_name', 'collector_issue'),
+            severity=severity,
+            message=issue_dict.get('message', ''),
+            details=issue_dict.get('details'),
+        ))
+
     report.checks_passed = checks_run - checks_failed
     report.checks_failed = checks_failed
 


### PR DESCRIPTION
## Summary

Bundles the three Luchtmeetnet follow-ups from PR #10's reviewer findings. All touch `collectors/luchtmeetnet.py` + `tests/unit/test_luchtmeetnet_cache.py`; #12 also adds a generic hook in `utils/data_quality.py` for collector-emitted issues.

## Changes

### #14 — Narrow `except Exception` in per-station detail-fetch
Old: `except Exception` swallowed everything including `AttributeError` from a future refactor mistake.
New: `except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError, ValueError, KeyError, TypeError)` — only realistic upstream-failure modes. Programmer errors surface immediately.

### #13 — Don't cache empty station list on total outage
Old: an empty fetch result was written into the 24h class-level cache, locking the collector out until TTL expired.
New: empty results return without persisting; the previously-good cache survives so subsequent calls within the original 24h window can still hit a sane snapshot.

### #12 — Emit `station_completeness` data-quality signal
Old: `n_filtered` was only a log line; no way for the workflow gate at `.github/workflows/collect-data.yml:52-64` to see it.
New: `_get_metadata` attaches a `collector_quality_issues` entry (warn ≥25% filtered, critical ≥50%). `data_quality.validate_dataset` now consumes any `collector_quality_issues` from metadata, so collector-specific signals flow into the same pipeline-level gate as the generic checks. Thresholds (`STATION_FILTER_WARN_THRESHOLD`, `STATION_FILTER_CRITICAL_THRESHOLD`) are module-level constants.

The new metadata→quality plumbing is generic — any collector can opt in by appending `{'check_name', 'severity', 'message', 'details'}` dicts to `metadata['collector_quality_issues']`.

## Tests

10 new tests in `tests/unit/test_luchtmeetnet_cache.py` (25 total in that file, all pass). Full suite: **406 passed**.

- `test_empty_station_list_not_cached` — inverts the original `test_empty_station_list_cached` (which documented the bug as intended behavior)
- `test_empty_fetch_does_not_overwrite_existing_cache` — new scenario from issue #13
- `TestLuchtmeetnetNarrowExcept::test_attribute_error_propagates_through_narrow_except` — proves AttributeError is no longer swallowed
- `TestLuchtmeetnetStationCompletenessQuality::*` — 5 tests covering 0%/20%/30%/60% thresholds + the stats snapshot path
- `TestDataQualityCollectorIssuesIntegration::test_collector_critical_issue_flips_dataset_status` — end-to-end: collector-emitted issue → `validate_dataset` → `report.status == 'critical'` (this is what the workflow gate checks)

## Test plan

- [x] `python -m pytest tests/unit/test_luchtmeetnet_cache.py -v` (25 passed)
- [x] `python -m pytest tests/ -x` (406 passed)

Closes #12, #13, #14. Follow-up to #10.