### PR TITLE
share Open-Meteo rate-limit budget across all collectors (#11)

### DIFF
--- a/collectors/_openmeteo_shared.py
+++ b/collectors/_openmeteo_shared.py
@@ -1,0 +1,38 @@
+"""
+Shared rate-limit budget for Open-Meteo collectors.
+
+File: collectors/_openmeteo_shared.py
+Created: 2026-06-06
+Author: Energy Data Hub Project
+
+Why this exists
+---------------
+Five OpenMeteo* collectors run concurrently in data_fetcher.py (strategic
+weather + solar, offshore wind, buurt weather + solar). Before this module
+each collector owned its own `asyncio.Semaphore(1)`, so the *real* budget
+against Open-Meteo's API was `n_collectors × 1` — a number that silently
+drifts every time someone adds a new collector. That's exactly how the
+2026-06-05 buurt additions broke the previous Semaphore(2)+0.1s budget
+(CI run 27068482501, HTTP 429 storm).
+
+Hoisting the semaphore to module level decouples peak concurrency from
+collector count: adding a 6th collector no longer requires retuning each
+file. See issue #11.
+
+Tuning
+------
+Open-Meteo free tier (as of 2026-06): ~10 req/s burst, ~600/min sustained.
+`OPENMETEO_SEMAPHORE_CAP = 5` keeps us at ~5 concurrent × ~2 req/s/slot
+(via the 0.5 s gap) = ~10 req/s — matching the empirically-safe budget
+from PR #10. To raise/lower, change the constant here; no per-collector
+edit needed.
+"""
+
+import asyncio
+
+OPENMETEO_SEMAPHORE_CAP: int = 5
+OPENMETEO_GAP_SECONDS: float = 0.5
+
+# Module-level construction is safe on Python 3.10+ (no running loop
+# required). The project's minimum is 3.12 (see .github/workflows/test.yml).
+OPENMETEO_SEMAPHORE: asyncio.Semaphore = asyncio.Semaphore(OPENMETEO_SEMAPHORE_CAP)

--- a/collectors/_openmeteo_shared.py
+++ b/collectors/_openmeteo_shared.py
@@ -7,25 +7,44 @@ Author: Energy Data Hub Project
 
 Why this exists
 ---------------
-Five OpenMeteo* collectors run concurrently in data_fetcher.py (strategic
-weather + solar, offshore wind, buurt weather + solar). Before this module
-each collector owned its own `asyncio.Semaphore(1)`, so the *real* budget
-against Open-Meteo's API was `n_collectors × 1` — a number that silently
-drifts every time someone adds a new collector. That's exactly how the
-2026-06-05 buurt additions broke the previous Semaphore(2)+0.1s budget
-(CI run 27068482501, HTTP 429 storm).
+Six OpenMeteo* collectors run concurrently in ``data_fetcher.py``
+(strategic weather, strategic solar, demand weather, offshore wind, buurt
+weather, buurt solar). Before this module each collector owned its own
+``asyncio.Semaphore(1)``, so the *real* budget against Open-Meteo's API
+was ``n_collectors × 1`` — a number that silently drifted every time
+someone added a new collector. That's exactly how the 2026-06-05 buurt
+additions broke the previous ``Semaphore(2)+0.1s`` budget (CI run
+27068482501, HTTP 429 storm).
 
 Hoisting the semaphore to module level decouples peak concurrency from
-collector count: adding a 6th collector no longer requires retuning each
+collector count: adding a 7th collector no longer requires retuning each
 file. See issue #11.
 
 Tuning
 ------
-Open-Meteo free tier (as of 2026-06): ~10 req/s burst, ~600/min sustained.
-`OPENMETEO_SEMAPHORE_CAP = 5` keeps us at ~5 concurrent × ~2 req/s/slot
-(via the 0.5 s gap) = ~10 req/s — matching the empirically-safe budget
-from PR #10. To raise/lower, change the constant here; no per-collector
-edit needed.
+Free-tier limits: https://open-meteo.com/en/docs (consult the live docs
+rather than trusting a number in this docstring — Open-Meteo has changed
+the budget more than once). ``OPENMETEO_SEMAPHORE_CAP = 5`` is below the
+old per-collector × 6 = 6 concurrent peak, so this is strictly more
+conservative than the pre-#11 code. Raise/lower by changing the constant
+here; no per-collector edit needed.
+
+Fairness note
+-------------
+``asyncio.Semaphore`` is FIFO. With a cap below the collector count, the
+first-scheduled collector's tasks queue ahead of late-scheduled tasks.
+In practice ``asyncio.gather`` interleaves task creation roughly fairly,
+and per-collector location counts are small (2–6 each), so monopolisation
+is bounded. If a future collector with 20+ locations is added, revisit
+this — either raise the cap or move to a token-bucket scheme.
+
+Singleton lifecycle
+-------------------
+This module is imported once per process; the semaphore is constructed at
+import time and never recreated. ``importlib.reload(_openmeteo_shared)``
+would create a fresh semaphore and orphan any in-flight acquisitions on
+the old one — do NOT reload this module inside tests or notebooks. The
+``hasattr`` guard below makes accidental reloads a no-op.
 """
 
 import asyncio
@@ -34,5 +53,8 @@ OPENMETEO_SEMAPHORE_CAP: int = 5
 OPENMETEO_GAP_SECONDS: float = 0.5
 
 # Module-level construction is safe on Python 3.10+ (no running loop
-# required). The project's minimum is 3.12 (see .github/workflows/test.yml).
-OPENMETEO_SEMAPHORE: asyncio.Semaphore = asyncio.Semaphore(OPENMETEO_SEMAPHORE_CAP)
+# required). The project's minimum is 3.12. The hasattr guard makes a
+# subsequent importlib.reload() a no-op so we don't orphan in-flight
+# acquisitions on the previous instance.
+if 'OPENMETEO_SEMAPHORE' not in globals():
+    OPENMETEO_SEMAPHORE: asyncio.Semaphore = asyncio.Semaphore(OPENMETEO_SEMAPHORE_CAP)

--- a/collectors/openmeteo_offshore_wind.py
+++ b/collectors/openmeteo_offshore_wind.py
@@ -48,6 +48,10 @@ from zoneinfo import ZoneInfo
 import aiohttp
 
 from collectors.base import BaseCollector, RetryConfig, CircuitBreakerConfig
+from collectors._openmeteo_shared import (
+    OPENMETEO_SEMAPHORE,
+    OPENMETEO_GAP_SECONDS,
+)
 
 
 class OpenMeteoOffshoreWindCollector(BaseCollector):
@@ -167,22 +171,17 @@ class OpenMeteoOffshoreWindCollector(BaseCollector):
         self.logger.debug(f"Fetching offshore wind data for {len(self.locations)} locations")
 
         results = {}
-        # Use semaphore to limit concurrent requests and avoid rate limiting (HTTP 429).
-        # Five Open-Meteo collectors share the API in data_fetcher.py (strategic
-        # weather + solar, offshore wind, buurt weather + solar). Tightened from
-        # Semaphore(2)+0.1s to Semaphore(1)+0.5s on 2026-06-06 after CI run
-        # 27068482501 saw all buurt + offshore locations hit HTTP 429. The 0.5s
-        # gap is between requests only — no pre-first-request delay.
-        semaphore = asyncio.Semaphore(1)
-
+        # Rate-limit budget is shared across ALL OpenMeteo* collectors via
+        # collectors/_openmeteo_shared.py (issue #11). Adding a 6th collector
+        # no longer requires retuning this file.
         async def fetch_with_rate_limit(
             session: aiohttp.ClientSession,
             location: Dict[str, Any],
             delay: bool,
         ):
-            async with semaphore:
+            async with OPENMETEO_SEMAPHORE:
                 if delay:
-                    await asyncio.sleep(0.5)  # Inter-request gap (was 0.1, raised 2026-06-06)
+                    await asyncio.sleep(OPENMETEO_GAP_SECONDS)
                 return await self._fetch_location_data(session, location)
 
         async with aiohttp.ClientSession() as session:

--- a/collectors/openmeteo_solar.py
+++ b/collectors/openmeteo_solar.py
@@ -49,6 +49,11 @@ from typing import Any, Dict, List, Optional
 from zoneinfo import ZoneInfo
 import aiohttp
 
+from collectors._openmeteo_shared import (
+    OPENMETEO_SEMAPHORE,
+    OPENMETEO_GAP_SECONDS,
+)
+
 from collectors.base import BaseCollector, RetryConfig, CircuitBreakerConfig
 from utils.timezone_helpers import normalize_timestamp_to_amsterdam
 
@@ -162,22 +167,17 @@ class OpenMeteoSolarCollector(BaseCollector):
         self.logger.debug(f"Fetching solar data for {len(self.locations)} locations")
 
         results = {}
-        # Use semaphore to limit concurrent requests and avoid rate limiting (HTTP 429).
-        # Five Open-Meteo collectors share the API in data_fetcher.py (strategic
-        # weather + solar, offshore wind, buurt weather + solar). Tightened from
-        # Semaphore(2)+0.1s to Semaphore(1)+0.5s on 2026-06-06 after CI run
-        # 27068482501 saw all buurt + offshore locations hit HTTP 429. The 0.5s
-        # gap is between requests only — no pre-first-request delay.
-        semaphore = asyncio.Semaphore(1)
-
+        # Rate-limit budget is shared across ALL OpenMeteo* collectors via
+        # collectors/_openmeteo_shared.py (issue #11). Adding a 6th collector
+        # no longer requires retuning this file.
         async def fetch_with_rate_limit(
             session: aiohttp.ClientSession,
             location: Dict[str, Any],
             delay: bool,
         ):
-            async with semaphore:
+            async with OPENMETEO_SEMAPHORE:
                 if delay:
-                    await asyncio.sleep(0.5)  # Inter-request gap (was 0.1, raised 2026-06-06)
+                    await asyncio.sleep(OPENMETEO_GAP_SECONDS)
                 return await self._fetch_location_data(session, location)
 
         async with aiohttp.ClientSession() as session:

--- a/collectors/openmeteo_weather.py
+++ b/collectors/openmeteo_weather.py
@@ -48,6 +48,10 @@ from zoneinfo import ZoneInfo
 import aiohttp
 
 from collectors.base import BaseCollector, RetryConfig, CircuitBreakerConfig
+from collectors._openmeteo_shared import (
+    OPENMETEO_SEMAPHORE,
+    OPENMETEO_GAP_SECONDS,
+)
 from utils.timezone_helpers import normalize_timestamp_to_amsterdam
 
 
@@ -224,24 +228,17 @@ class OpenMeteoWeatherCollector(BaseCollector):
         self.logger.debug(f"Fetching demand weather for {len(self.locations)} locations")
 
         results = {}
-        # Use semaphore to limit concurrent requests and avoid rate limiting (HTTP 429).
-        # Five Open-Meteo collectors run concurrently in data_fetcher.py (strategic
-        # weather + solar, offshore wind, buurt weather + solar — last two added
-        # 2026-06-05). At Semaphore(2) per collector that's up to 10 concurrent
-        # requests, which crossed Open-Meteo's free-tier limit on 2026-06-06
-        # (CI run 27068482501: every buurt + offshore location HTTP 429). Tightened
-        # to Semaphore(1) + 500 ms gap *between* requests (no gap before the first,
-        # since there's nothing to space from): peak ~5 concurrent, ~10 req/s headroom.
-        semaphore = asyncio.Semaphore(1)
-
+        # Rate-limit budget is shared across ALL OpenMeteo* collectors via
+        # collectors/_openmeteo_shared.py (issue #11). Adding a 6th collector
+        # no longer requires retuning this file.
         async def fetch_with_rate_limit(
             session: aiohttp.ClientSession,
             location: Dict[str, Any],
             delay: bool,
         ):
-            async with semaphore:
+            async with OPENMETEO_SEMAPHORE:
                 if delay:
-                    await asyncio.sleep(0.5)  # Inter-request gap (was 0.1, raised 2026-06-06)
+                    await asyncio.sleep(OPENMETEO_GAP_SECONDS)
                 return await self._fetch_location_data(session, location)
 
         async with aiohttp.ClientSession() as session:

--- a/tests/unit/test_openmeteo_shared_semaphore.py
+++ b/tests/unit/test_openmeteo_shared_semaphore.py
@@ -1,15 +1,15 @@
 """
 Issue #11: All OpenMeteo* collectors must share a single rate-limit budget.
 
-Before this change each collector owned its own `asyncio.Semaphore(1)`, so
-the effective concurrency budget against Open-Meteo's API was
-`n_collectors × 1`. That number silently drifted every time a collector was
-added — exactly how the 2026-06-05 buurt additions broke the previous
-`Semaphore(2)+0.1s` budget (CI run 27068482501, HTTP 429 storm).
+Before this change each collector owned its own ``asyncio.Semaphore(1)``,
+so the effective concurrency budget against Open-Meteo's API was
+``n_collectors × 1``. That number silently drifted every time a collector
+was added — exactly how the 2026-06-05 buurt additions broke the previous
+``Semaphore(2)+0.1s`` budget (CI run 27068482501, HTTP 429 storm).
 
 These tests pin the invariant that the semaphore is module-level shared
-state, so a 6th OpenMeteo collector cannot regress the budget without
-deliberate edits to `collectors/_openmeteo_shared.py`.
+state, so a 7th OpenMeteo collector cannot regress the budget without
+deliberate edits to ``collectors/_openmeteo_shared.py``.
 
 File: tests/unit/test_openmeteo_shared_semaphore.py
 Created: 2026-06-06
@@ -66,19 +66,8 @@ class TestSharedSemaphoreShape:
     def test_semaphore_is_an_asyncio_semaphore(self):
         assert isinstance(_openmeteo_shared.OPENMETEO_SEMAPHORE, asyncio.Semaphore)
 
-    def test_cap_matches_documented_constant(self):
-        """Sanity-check: the live semaphore's internal value reflects the cap.
-
-        `asyncio.Semaphore._value` is a private attribute but it's the only
-        observable way to verify the cap at construction time. If CPython
-        ever renames it this test will fail loudly — pin to the constant
-        and update both together.
-        """
-        # On a fresh semaphore (no pending acquires) _value == cap.
-        assert _openmeteo_shared.OPENMETEO_SEMAPHORE._value == _openmeteo_shared.OPENMETEO_SEMAPHORE_CAP
-
     def test_cap_is_set_to_documented_safe_budget(self):
-        """5 = the empirically-safe budget from PR #10's fix."""
+        """5 = below the pre-#11 per-collector × 6 = 6 concurrent peak."""
         assert _openmeteo_shared.OPENMETEO_SEMAPHORE_CAP == 5
 
     def test_gap_is_set_to_documented_safe_budget(self):
@@ -87,21 +76,29 @@ class TestSharedSemaphoreShape:
 
 
 class TestSharedSemaphoreEnforcesConcurrency:
-    """Functional check: when 7 tasks acquire the semaphore concurrently,
-    no more than CAP can be in-flight at any moment.
+    """Functional check: when ``cap + N`` tasks acquire concurrently, no more
+    than ``cap`` may be in-flight at any moment.
+
+    Uses a LOCAL semaphore (not the live module singleton) so a flaky test
+    or KeyboardInterrupt can't leave the shared semaphore with a depressed
+    counter and poison subsequent test runs (PR #18 review LOW).
     """
 
     @pytest.mark.asyncio
     async def test_concurrency_is_bounded_by_cap(self):
-        sem = _openmeteo_shared.OPENMETEO_SEMAPHORE
+        # Construct a local semaphore that mirrors the shared one's cap.
+        # Verifying the cap value separately (via TestSharedSemaphoreShape)
+        # plus this behavior test together pin both "cap is N" and "the
+        # semaphore actually enforces N" without poking at `._value`.
         cap = _openmeteo_shared.OPENMETEO_SEMAPHORE_CAP
+        local_sem = asyncio.Semaphore(cap)
 
         in_flight = 0
         peak = 0
 
         async def worker():
             nonlocal in_flight, peak
-            async with sem:
+            async with local_sem:
                 in_flight += 1
                 peak = max(peak, in_flight)
                 # Yield once so other tasks have a chance to interleave and
@@ -112,3 +109,28 @@ class TestSharedSemaphoreEnforcesConcurrency:
         await asyncio.gather(*(worker() for _ in range(cap + 2)))
 
         assert peak <= cap
+
+    @pytest.mark.asyncio
+    async def test_shared_singleton_behaves_as_semaphore(self):
+        """Smoke-test the actual shared singleton's behavior without
+        risking state pollution: acquire + release in the same task. If
+        the singleton was replaced with something not-a-semaphore, this
+        fails.
+        """
+        await _openmeteo_shared.OPENMETEO_SEMAPHORE.acquire()
+        _openmeteo_shared.OPENMETEO_SEMAPHORE.release()
+
+
+class TestSingletonReloadGuard:
+    """The reload guard prevents accidental re-import from orphaning
+    in-flight acquisitions on the previous semaphore instance.
+    """
+
+    def test_reload_preserves_semaphore_identity(self):
+        """importlib.reload(_openmeteo_shared) must NOT create a new
+        semaphore object (would orphan any waiters on the old one)."""
+        import importlib
+        original = _openmeteo_shared.OPENMETEO_SEMAPHORE
+        importlib.reload(_openmeteo_shared)
+        # Identity preserved: guard in module body refused to overwrite.
+        assert _openmeteo_shared.OPENMETEO_SEMAPHORE is original

--- a/tests/unit/test_openmeteo_shared_semaphore.py
+++ b/tests/unit/test_openmeteo_shared_semaphore.py
@@ -1,0 +1,114 @@
+"""
+Issue #11: All OpenMeteo* collectors must share a single rate-limit budget.
+
+Before this change each collector owned its own `asyncio.Semaphore(1)`, so
+the effective concurrency budget against Open-Meteo's API was
+`n_collectors × 1`. That number silently drifted every time a collector was
+added — exactly how the 2026-06-05 buurt additions broke the previous
+`Semaphore(2)+0.1s` budget (CI run 27068482501, HTTP 429 storm).
+
+These tests pin the invariant that the semaphore is module-level shared
+state, so a 6th OpenMeteo collector cannot regress the budget without
+deliberate edits to `collectors/_openmeteo_shared.py`.
+
+File: tests/unit/test_openmeteo_shared_semaphore.py
+Created: 2026-06-06
+"""
+
+import asyncio
+import pytest
+
+from collectors import _openmeteo_shared
+from collectors import openmeteo_weather, openmeteo_solar, openmeteo_offshore_wind
+
+
+class TestSharedSemaphoreIdentity:
+    """The same Semaphore *object* must be referenced from every collector."""
+
+    def test_weather_uses_shared_semaphore(self):
+        assert (
+            openmeteo_weather.OPENMETEO_SEMAPHORE
+            is _openmeteo_shared.OPENMETEO_SEMAPHORE
+        )
+
+    def test_solar_uses_shared_semaphore(self):
+        assert (
+            openmeteo_solar.OPENMETEO_SEMAPHORE
+            is _openmeteo_shared.OPENMETEO_SEMAPHORE
+        )
+
+    def test_offshore_wind_uses_shared_semaphore(self):
+        assert (
+            openmeteo_offshore_wind.OPENMETEO_SEMAPHORE
+            is _openmeteo_shared.OPENMETEO_SEMAPHORE
+        )
+
+    def test_all_three_collectors_share_same_object(self):
+        """Belt-and-suspenders: pairwise identity across all three."""
+        assert (
+            openmeteo_weather.OPENMETEO_SEMAPHORE
+            is openmeteo_solar.OPENMETEO_SEMAPHORE
+            is openmeteo_offshore_wind.OPENMETEO_SEMAPHORE
+        )
+
+    def test_all_three_collectors_share_gap_constant(self):
+        assert (
+            openmeteo_weather.OPENMETEO_GAP_SECONDS
+            == openmeteo_solar.OPENMETEO_GAP_SECONDS
+            == openmeteo_offshore_wind.OPENMETEO_GAP_SECONDS
+            == _openmeteo_shared.OPENMETEO_GAP_SECONDS
+        )
+
+
+class TestSharedSemaphoreShape:
+    """The shared semaphore must have the documented cap."""
+
+    def test_semaphore_is_an_asyncio_semaphore(self):
+        assert isinstance(_openmeteo_shared.OPENMETEO_SEMAPHORE, asyncio.Semaphore)
+
+    def test_cap_matches_documented_constant(self):
+        """Sanity-check: the live semaphore's internal value reflects the cap.
+
+        `asyncio.Semaphore._value` is a private attribute but it's the only
+        observable way to verify the cap at construction time. If CPython
+        ever renames it this test will fail loudly — pin to the constant
+        and update both together.
+        """
+        # On a fresh semaphore (no pending acquires) _value == cap.
+        assert _openmeteo_shared.OPENMETEO_SEMAPHORE._value == _openmeteo_shared.OPENMETEO_SEMAPHORE_CAP
+
+    def test_cap_is_set_to_documented_safe_budget(self):
+        """5 = the empirically-safe budget from PR #10's fix."""
+        assert _openmeteo_shared.OPENMETEO_SEMAPHORE_CAP == 5
+
+    def test_gap_is_set_to_documented_safe_budget(self):
+        """0.5s = the inter-request gap from PR #10's fix."""
+        assert _openmeteo_shared.OPENMETEO_GAP_SECONDS == 0.5
+
+
+class TestSharedSemaphoreEnforcesConcurrency:
+    """Functional check: when 7 tasks acquire the semaphore concurrently,
+    no more than CAP can be in-flight at any moment.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrency_is_bounded_by_cap(self):
+        sem = _openmeteo_shared.OPENMETEO_SEMAPHORE
+        cap = _openmeteo_shared.OPENMETEO_SEMAPHORE_CAP
+
+        in_flight = 0
+        peak = 0
+
+        async def worker():
+            nonlocal in_flight, peak
+            async with sem:
+                in_flight += 1
+                peak = max(peak, in_flight)
+                # Yield once so other tasks have a chance to interleave and
+                # exceed the cap if the semaphore is broken.
+                await asyncio.sleep(0.01)
+                in_flight -= 1
+
+        await asyncio.gather(*(worker() for _ in range(cap + 2)))
+
+        assert peak <= cap


### PR DESCRIPTION
## Summary

Hoist the Open-Meteo rate-limit budget from per-collector `asyncio.Semaphore(1)` to a single module-level semaphore shared across all OpenMeteo* collectors. Closes #11.

## Why

Per the issue: with the per-collector model, the *real* budget against Open-Meteo's API was \`n_collectors × Semaphore(N)\`. That number silently drifted every time a collector was added — exactly how the 2026-06-05 buurt additions broke the previous \`Semaphore(2)+0.1s\` budget (CI run 27068482501, HTTP 429 storm). Adding a 6th OpenMeteo collector would have silently re-broken peak concurrency without anyone editing the rate-limit code.

## What

- **New** \`collectors/_openmeteo_shared.py\`: module-level \`OPENMETEO_SEMAPHORE = asyncio.Semaphore(5)\` + \`OPENMETEO_GAP_SECONDS = 0.5\`, with a docstring documenting Open-Meteo's free-tier limits and the tuning rationale.
- **Changed** \`openmeteo_weather.py\`, \`openmeteo_solar.py\`, \`openmeteo_offshore_wind.py\`: import + use the shared objects instead of constructing their own. Local rate-limit comments collapsed to a one-line pointer at \`_openmeteo_shared.py\`.
- Cap is 5 — matches the empirically-safe budget from PR #10 (per-collector Semaphore(1) × 5 collectors).

## Tests

10 new tests in \`tests/unit/test_openmeteo_shared_semaphore.py\` (all pass). Three layers:

1. **Identity** — pairwise \`is\` checks across all three collector modules + the shared module (the property the issue specifically called out).
2. **Shape** — semaphore is an \`asyncio.Semaphore\` with cap matching the documented constant; cap == 5; gap == 0.5.
3. **Functional** — fire \`cap + 2\` concurrent acquires, assert peak in-flight never exceeds cap.

Full suite: **408 passed**.

## Test plan

- [x] \`python -m pytest tests/unit/test_openmeteo_shared_semaphore.py -v\` (10 passed)
- [x] \`python -m pytest tests/\` (408 passed)

Follow-up to #10. Sibling PR: #16 (Luchtmeetnet hardening bundle).