### PR TITLE
homogenize buurt air-quality envelope to match weather/solar (#17)

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -113,6 +113,64 @@ MAX_RETRY_ROUNDS = 3       # Up to 3 retry rounds for failed critical collectors
 # Critical datasets — if these are missing, Augur's forecast breaks
 CRITICAL_DATASETS = {'entsoe', 'entsoe_de'}
 
+
+def assemble_buurt_air_envelope(buurt_locations, buurt_aq_data):
+    """Combine per-location Luchtmeetnet datasets into one EnhancedDataSet.
+
+    Issue #17: the air-quality buurt feed previously used a CombinedDataSet,
+    which serialises to ``{version, loc1: {...}, loc2: {...}}`` — location
+    keys at the root, no top-level ``metadata``/``data`` envelope. The
+    weather and solar buurt feeds publish as ``{metadata, data: {loc: {...}}}``.
+    This mismatch silently broke FyE's consumer (saw ``available: []``)
+    after PR #10's cron ran. Returning a single EnhancedDataSet with
+    ``data`` keyed by location pins the envelope to the same shape as the
+    other two buurt feeds.
+
+    Per-location station info (RIVM station number, coordinates, city) is
+    preserved in ``metadata['stations'][<loc>]``. Per-location
+    ``collector_quality_issues`` are aggregated into top-level
+    ``metadata['collector_quality_issues']`` (with ``details['location']``
+    set) so the pipeline-level data-quality gate still sees them after the
+    flatten.
+
+    Returns:
+        EnhancedDataSet ready for save_data_file, or None when none of the
+        per-location collectors returned data.
+    """
+    buurt_air_data = {}
+    buurt_air_stations = {}
+    buurt_air_quality_issues = []
+    for loc, aq_ds in zip(buurt_locations, buurt_aq_data):
+        if not aq_ds:
+            continue
+        buurt_air_data[loc['name']] = aq_ds.data
+        buurt_air_stations[loc['name']] = {
+            k: aq_ds.metadata.get(k) for k in (
+                'station', 'station_location', 'station_latitude',
+                'station_longitude', 'requested_latitude',
+                'requested_longitude', 'city',
+            )
+        }
+        for issue in (aq_ds.metadata.get('collector_quality_issues') or []):
+            tagged = dict(issue)
+            tagged.setdefault('details', {})['location'] = loc['name']
+            buurt_air_quality_issues.append(tagged)
+
+    if not buurt_air_data:
+        return None
+
+    air_metadata = {
+        'data_type': 'air',
+        'source': 'Luchtmeetnet API',
+        'units': 'µg/m³',
+        'locations': list(buurt_air_data.keys()),
+        'stations': buurt_air_stations,
+    }
+    if buurt_air_quality_issues:
+        air_metadata['collector_quality_issues'] = buurt_air_quality_issues
+    return EnhancedDataSet(metadata=air_metadata, data=buurt_air_data)
+
+
 # Setup logging with UTF-8 encoding (Windows console defaults to cp1252)
 _stream_handler = logging.StreamHandler()
 _stream_handler.stream = open(sys.stdout.fileno(), mode='w', encoding='utf-8', closefd=False)
@@ -663,22 +721,14 @@ async def main() -> None:
             logging.info(f"Saved buurt solar irradiance forecast for {len(buurt_locations)} neighbourhoods (FyE B1)")
 
         # Save buurt-level air quality (FyE B1 transdisciplinary signal).
-        # Combines per-buurt Luchtmeetnet datasets into one envelope, keyed by
-        # location name. Historical 24h window, snaps to nearest RIVM station.
-        # NOTE schema divergence: wind_forecast.json keys its CombinedDataSet
-        # datasets by SOURCE type ('entsoe_wind_generation', 'offshore_wind');
-        # air_quality_buurt.json keys by LOCATION name ('Elsweide_Arnhem_NL',
-        # 'Elderveld_Arnhem_NL'). Both are intentional but mean any consumer
-        # iterating .datasets must understand the key semantics per-file.
-        buurt_air_combined = CombinedDataSet()
-        for loc, aq_ds in zip(buurt_locations, buurt_aq_data):
-            if aq_ds:
-                buurt_air_combined.add_dataset(loc['name'], aq_ds)
-        if buurt_air_combined.datasets:
+        # Envelope shape pinned by `assemble_buurt_air_envelope` to match
+        # weather_forecast_buurt.json / solar_forecast_buurt.json — see #17.
+        buurt_air_combined = assemble_buurt_air_envelope(buurt_locations, buurt_aq_data)
+        if buurt_air_combined is not None:
             full_path = os.path.join(output_path, f"{datetime.now().strftime('%y%m%d_%H%M%S')}_air_quality_buurt.json")
             save_data_file(data=buurt_air_combined, file_path=full_path, handler=handler, encrypt=encryption)
             shutil.copy(full_path, os.path.join(output_path, "air_quality_buurt.json"))
-            logging.info(f"Saved buurt air quality (Luchtmeetnet) for {len(buurt_air_combined.datasets)} neighbourhoods (FyE B1)")
+            logging.info(f"Saved buurt air quality (Luchtmeetnet) for {len(buurt_air_combined.data)} neighbourhoods (FyE B1)")
 
         # Save cross-border flows data (import/export between NL and neighbors)
         if flows_data:
@@ -863,7 +913,7 @@ async def main() -> None:
             'weather_forecast_multi_location': strategic_weather_data,
             'weather_forecast_buurt': buurt_weather_data,
             'solar_forecast_buurt': buurt_solar_data,
-            'air_quality_buurt': buurt_air_combined if buurt_air_combined.datasets else None,
+            'air_quality_buurt': buurt_air_combined,  # None when no buurt locations collected; see #17
             'grid_imbalance': tennet_data,
             'wind_forecast': entsoe_wind_data,
             'solar_forecast': solar_data,

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -59,6 +59,7 @@ Notes:
 import os
 import sys
 import json
+import copy
 import shutil
 import configparser
 from datetime import datetime, timedelta
@@ -114,6 +115,18 @@ MAX_RETRY_ROUNDS = 3       # Up to 3 retry rounds for failed critical collectors
 CRITICAL_DATASETS = {'entsoe', 'entsoe_de'}
 
 
+# Per-location Luchtmeetnet metadata fields preserved (per-station) under
+# `metadata['stations'][<loc>]` in the buurt air-quality envelope.
+# `components` is the list of pollutants the station actually measures —
+# critical for downstream consumers to validate that a station reports the
+# pollutant they're looking at (PR #20 review HIGH-2).
+_BUURT_AIR_STATION_FIELDS = (
+    'station', 'station_location', 'station_latitude',
+    'station_longitude', 'requested_latitude', 'requested_longitude',
+    'city', 'components',
+)
+
+
 def assemble_buurt_air_envelope(buurt_locations, buurt_aq_data):
     """Combine per-location Luchtmeetnet datasets into one EnhancedDataSet.
 
@@ -126,39 +139,65 @@ def assemble_buurt_air_envelope(buurt_locations, buurt_aq_data):
     ``data`` keyed by location pins the envelope to the same shape as the
     other two buurt feeds.
 
-    Per-location station info (RIVM station number, coordinates, city) is
-    preserved in ``metadata['stations'][<loc>]``. Per-location
-    ``collector_quality_issues`` are aggregated into top-level
-    ``metadata['collector_quality_issues']`` (with ``details['location']``
-    set) so the pipeline-level data-quality gate still sees them after the
-    flatten.
+    Per-location station info (RIVM station number, coordinates, city,
+    components) is preserved in ``metadata['stations'][<loc>]``. Per-
+    location ``collector_quality_issues`` are aggregated into top-level
+    ``metadata['collector_quality_issues']`` with ``details['location']``
+    tagged, so the pipeline data-quality gate (PR #16 wiring) still sees
+    them after the flatten.
+
+    Defensive copies: the envelope's ``data`` and aggregated ``issues``
+    are deep-copied from the source datasets, so subsequent mutations on
+    either side cannot poison the other (PR #20 review HIGH/MEDIUM).
+
+    Args:
+        buurt_locations: list of dicts with at least a ``name`` key.
+        buurt_aq_data: list of EnhancedDataSet (or None on per-buurt
+            collector failure), same length and order as ``buurt_locations``.
 
     Returns:
         EnhancedDataSet ready for save_data_file, or None when none of the
         per-location collectors returned data.
+
+    Raises:
+        ValueError: if input lists have different lengths (would indicate
+            a wiring mistake in the orchestrator; silent ``zip`` truncation
+            would otherwise drop the tail without notice).
     """
+    if len(buurt_locations) != len(buurt_aq_data):
+        raise ValueError(
+            f"assemble_buurt_air_envelope: input length mismatch — "
+            f"{len(buurt_locations)} locations vs {len(buurt_aq_data)} "
+            f"results. Check the orchestrator's task wiring."
+        )
+
     buurt_air_data = {}
     buurt_air_stations = {}
     buurt_air_quality_issues = []
     for loc, aq_ds in zip(buurt_locations, buurt_aq_data):
         if not aq_ds:
             continue
-        buurt_air_data[loc['name']] = aq_ds.data
+        # Deep-copy the per-location data so subsequent mutations on the
+        # collector's `aq_ds.data` (e.g., a future debug logger updating
+        # it in place) cannot poison the published envelope (PR #20
+        # review MEDIUM).
+        buurt_air_data[loc['name']] = copy.deepcopy(aq_ds.data)
         buurt_air_stations[loc['name']] = {
-            k: aq_ds.metadata.get(k) for k in (
-                'station', 'station_location', 'station_latitude',
-                'station_longitude', 'requested_latitude',
-                'requested_longitude', 'city',
-            )
+            k: aq_ds.metadata.get(k) for k in _BUURT_AIR_STATION_FIELDS
         }
         for issue in (aq_ds.metadata.get('collector_quality_issues') or []):
-            tagged = dict(issue)
+            # Deep-copy so adding `details.location` here does NOT mutate
+            # the collector's original issue dict (PR #20 review HIGH).
+            tagged = copy.deepcopy(issue)
             tagged.setdefault('details', {})['location'] = loc['name']
             buurt_air_quality_issues.append(tagged)
 
     if not buurt_air_data:
         return None
 
+    # `locations` mirrors `data.keys()` deliberately: consumers reading only
+    # the metadata block (without traversing `data`) get the list directly,
+    # matching weather/solar buurt feed convention.
     air_metadata = {
         'data_type': 'air',
         'source': 'Luchtmeetnet API',

--- a/tests/unit/test_buurt_air_envelope.py
+++ b/tests/unit/test_buurt_air_envelope.py
@@ -1,0 +1,164 @@
+"""
+Issue #17: pins the published shape of `air_quality_buurt.json` to match
+`weather_forecast_buurt.json` / `solar_forecast_buurt.json` so consumers
+can use one envelope-traversal code path for all three buurt feeds.
+
+Before this fix the air-quality file was a CombinedDataSet, serialising to
+{version, loc1: {...}, loc2: {...}} — location keys at the root, no
+top-level metadata/data wrapper. FyE silently saw `available: []` after
+PR #10's cron ran.
+
+File: tests/unit/test_buurt_air_envelope.py
+Created: 2026-06-06
+"""
+
+import pytest
+
+from data_fetcher import assemble_buurt_air_envelope
+from utils.data_types import EnhancedDataSet
+
+
+def _ds(station, ts_to_pollutants, extra_meta=None):
+    """Build a per-location Luchtmeetnet-shaped EnhancedDataSet."""
+    metadata = {
+        'data_type': 'air',
+        'source': 'Luchtmeetnet API',
+        'units': 'µg/m³',
+        'station': station,
+        'station_location': f'{station}_loc',
+        'station_latitude': 52.0,
+        'station_longitude': 4.0,
+        'requested_latitude': 51.9,
+        'requested_longitude': 3.9,
+        'city': 'Arnhem',
+    }
+    if extra_meta:
+        metadata.update(extra_meta)
+    return EnhancedDataSet(metadata=metadata, data=ts_to_pollutants)
+
+
+class TestEnvelopeShape:
+    """The envelope must match the {metadata, data: {loc: {...}}} shape used
+    by the weather/solar buurt feeds. This is the core invariant the issue
+    fixes — every test in this class would have failed against the old
+    CombinedDataSet-based assembler.
+    """
+
+    def test_returns_enhanced_dataset_not_combined(self):
+        locs = [{'name': 'L1', 'lat': 52.0, 'lon': 4.0}]
+        ds = _ds('NL001', {'2026-06-06T12:00:00+02:00': {'NO2': 20.0}})
+        result = assemble_buurt_air_envelope(locs, [ds])
+        assert isinstance(result, EnhancedDataSet)
+        # CombinedDataSet would have `.datasets`; EnhancedDataSet has `.data`.
+        assert hasattr(result, 'data')
+        assert not hasattr(result, 'datasets')
+
+    def test_payload_has_metadata_and_data_at_top_level(self):
+        locs = [{'name': 'L1', 'lat': 52.0, 'lon': 4.0}]
+        ds = _ds('NL001', {'2026-06-06T12:00:00+02:00': {'NO2': 20.0}})
+        payload = assemble_buurt_air_envelope(locs, [ds]).to_dict()
+        assert set(payload.keys()) == {'metadata', 'data'}
+
+    def test_data_block_keyed_by_location_name(self):
+        locs = [
+            {'name': 'Elsweide_Arnhem_NL', 'lat': 52.0, 'lon': 4.0},
+            {'name': 'Elderveld_Arnhem_NL', 'lat': 52.1, 'lon': 4.1},
+        ]
+        datasets = [
+            _ds('NL001', {'2026-06-06T12:00:00+02:00': {'NO2': 20.0}}),
+            _ds('NL002', {'2026-06-06T12:00:00+02:00': {'PM10': 15.0}}),
+        ]
+        payload = assemble_buurt_air_envelope(locs, datasets).to_dict()
+        assert set(payload['data'].keys()) == {'Elsweide_Arnhem_NL', 'Elderveld_Arnhem_NL'}
+
+    def test_no_version_key_at_root(self):
+        """Regression: CombinedDataSet wrote `version` at root; new envelope
+        must not. If a future refactor reintroduces it, this test fails."""
+        locs = [{'name': 'L1', 'lat': 52.0, 'lon': 4.0}]
+        ds = _ds('NL001', {'2026-06-06T12:00:00+02:00': {'NO2': 20.0}})
+        payload = assemble_buurt_air_envelope(locs, [ds]).to_dict()
+        assert 'version' not in payload
+
+
+class TestStationMetadataPreservation:
+    """Per-location station info must survive the flatten (closest RIVM
+    station + coordinates per buurt) — moved into metadata['stations']."""
+
+    def test_stations_dict_keyed_by_location_name(self):
+        locs = [
+            {'name': 'L1', 'lat': 52.0, 'lon': 4.0},
+            {'name': 'L2', 'lat': 53.0, 'lon': 5.0},
+        ]
+        datasets = [
+            _ds('NL001', {'2026-06-06T12:00:00+02:00': {'NO2': 20.0}}),
+            _ds('NL002', {'2026-06-06T12:00:00+02:00': {'PM10': 15.0}}),
+        ]
+        payload = assemble_buurt_air_envelope(locs, datasets).to_dict()
+        assert set(payload['metadata']['stations'].keys()) == {'L1', 'L2'}
+        assert payload['metadata']['stations']['L1']['station'] == 'NL001'
+        assert payload['metadata']['stations']['L2']['station'] == 'NL002'
+
+
+class TestQualityIssueAggregation:
+    """Per-location collector_quality_issues must aggregate to top-level
+    so the pipeline data-quality gate still sees them after the flatten."""
+
+    def test_aggregates_quality_issues_with_location_tag(self):
+        locs = [
+            {'name': 'L1', 'lat': 52.0, 'lon': 4.0},
+            {'name': 'L2', 'lat': 53.0, 'lon': 5.0},
+        ]
+        ds_with_issue = _ds(
+            'NL002',
+            {'2026-06-06T12:00:00+02:00': {'PM10': 15.0}},
+            extra_meta={
+                'collector_quality_issues': [{
+                    'check_name': 'station_completeness',
+                    'severity': 'critical',
+                    'message': '60/100 stations filtered',
+                    'details': {'filtered': 60, 'total': 100},
+                }],
+            },
+        )
+        ds_clean = _ds('NL001', {'2026-06-06T12:00:00+02:00': {'NO2': 20.0}})
+
+        payload = assemble_buurt_air_envelope(locs, [ds_clean, ds_with_issue]).to_dict()
+
+        issues = payload['metadata'].get('collector_quality_issues', [])
+        assert len(issues) == 1
+        assert issues[0]['check_name'] == 'station_completeness'
+        # Location tag was added so downstream consumers can identify which
+        # buurt the issue came from.
+        assert issues[0]['details']['location'] == 'L2'
+        # Original detail fields preserved.
+        assert issues[0]['details']['filtered'] == 60
+
+    def test_no_issues_key_when_all_locations_clean(self):
+        locs = [{'name': 'L1', 'lat': 52.0, 'lon': 4.0}]
+        ds = _ds('NL001', {'2026-06-06T12:00:00+02:00': {'NO2': 20.0}})
+        payload = assemble_buurt_air_envelope(locs, [ds]).to_dict()
+        assert 'collector_quality_issues' not in payload['metadata']
+
+
+class TestEmptyInputs:
+    """Defensive: when all per-location collectors returned None (total
+    outage), the assembler must return None so the caller skips the save
+    block instead of writing a half-empty envelope.
+    """
+
+    def test_all_none_returns_none(self):
+        locs = [{'name': 'L1', 'lat': 52.0, 'lon': 4.0}]
+        assert assemble_buurt_air_envelope(locs, [None]) is None
+
+    def test_empty_lists_returns_none(self):
+        assert assemble_buurt_air_envelope([], []) is None
+
+    def test_partial_success_includes_only_succeeded_locations(self):
+        locs = [
+            {'name': 'L1', 'lat': 52.0, 'lon': 4.0},
+            {'name': 'L2', 'lat': 53.0, 'lon': 5.0},
+        ]
+        ds = _ds('NL001', {'2026-06-06T12:00:00+02:00': {'NO2': 20.0}})
+        payload = assemble_buurt_air_envelope(locs, [ds, None]).to_dict()
+        assert list(payload['data'].keys()) == ['L1']
+        assert payload['metadata']['locations'] == ['L1']

--- a/tests/unit/test_buurt_air_envelope.py
+++ b/tests/unit/test_buurt_air_envelope.py
@@ -18,8 +18,13 @@ from data_fetcher import assemble_buurt_air_envelope
 from utils.data_types import EnhancedDataSet
 
 
-def _ds(station, ts_to_pollutants, extra_meta=None):
-    """Build a per-location Luchtmeetnet-shaped EnhancedDataSet."""
+def _ds(station, ts_to_pollutants, extra_meta=None, components=None):
+    """Build a per-location Luchtmeetnet-shaped EnhancedDataSet.
+
+    Matches the actual key set produced by `LuchtmeetnetCollector._get_metadata`
+    (including `components`) so envelope tests don't pass on incomplete
+    fixtures.
+    """
     metadata = {
         'data_type': 'air',
         'source': 'Luchtmeetnet API',
@@ -31,6 +36,7 @@ def _ds(station, ts_to_pollutants, extra_meta=None):
         'requested_latitude': 51.9,
         'requested_longitude': 3.9,
         'city': 'Arnhem',
+        'components': components if components is not None else ['NO2', 'PM10'],
     }
     if extra_meta:
         metadata.update(extra_meta)
@@ -97,6 +103,95 @@ class TestStationMetadataPreservation:
         assert set(payload['metadata']['stations'].keys()) == {'L1', 'L2'}
         assert payload['metadata']['stations']['L1']['station'] == 'NL001'
         assert payload['metadata']['stations']['L2']['station'] == 'NL002'
+
+    def test_components_field_preserved_per_station(self):
+        """PR #20 review HIGH/MEDIUM: `components` (the list of pollutants
+        the station actually measures) must be preserved. Without it,
+        downstream consumers cannot validate that a snapped station
+        actually reports the pollutant they're consuming.
+        """
+        locs = [
+            {'name': 'L1', 'lat': 52.0, 'lon': 4.0},
+            {'name': 'L2', 'lat': 53.0, 'lon': 5.0},
+        ]
+        datasets = [
+            _ds('NL001', {'2026-06-06T12:00:00+02:00': {'NO2': 20.0}},
+                components=['NO', 'NO2', 'NOX', 'PM10', 'PM25']),
+            _ds('NL002', {'2026-06-06T12:00:00+02:00': {'PM10': 15.0}},
+                components=['PM10', 'PM25']),
+        ]
+        payload = assemble_buurt_air_envelope(locs, datasets).to_dict()
+        assert payload['metadata']['stations']['L1']['components'] == [
+            'NO', 'NO2', 'NOX', 'PM10', 'PM25'
+        ]
+        assert payload['metadata']['stations']['L2']['components'] == ['PM10', 'PM25']
+
+
+class TestMutationIsolation:
+    """PR #20 review HIGH+MEDIUM: deep copies must isolate the published
+    envelope from the source collector's state. Any mutation on either
+    side after assembly must NOT leak to the other.
+    """
+
+    def test_issue_details_location_tag_does_not_mutate_source(self):
+        """Adding `details.location` during aggregation must not mutate
+        the original issue dict on the collector's metadata. Before the
+        fix this was a shallow `dict(issue)` copy, so the inner `details`
+        dict was shared.
+        """
+        locs = [{'name': 'L_BUURT_X', 'lat': 52.0, 'lon': 4.0}]
+        original_details = {'filtered': 60, 'total': 100}
+        original_issue = {
+            'check_name': 'station_completeness',
+            'severity': 'critical',
+            'message': 'degraded',
+            'details': original_details,
+        }
+        ds = _ds(
+            'NL001',
+            {'2026-06-06T12:00:00+02:00': {'NO2': 20.0}},
+            extra_meta={'collector_quality_issues': [original_issue]},
+        )
+
+        assemble_buurt_air_envelope(locs, [ds])
+
+        # The collector's original issue dict must NOT have gained `location`.
+        assert 'location' not in original_issue['details']
+        assert original_details == {'filtered': 60, 'total': 100}
+
+    def test_published_data_isolated_from_source(self):
+        """PR #20 review MEDIUM: the envelope's `data[<loc>]` must be a
+        copy, not a reference to `aq_ds.data`. Otherwise any downstream
+        mutation of either side poisons the other.
+        """
+        locs = [{'name': 'L1', 'lat': 52.0, 'lon': 4.0}]
+        source_data = {'2026-06-06T12:00:00+02:00': {'NO2': 20.0}}
+        ds = _ds('NL001', source_data)
+
+        envelope = assemble_buurt_air_envelope(locs, [ds])
+
+        # Mutate the source AFTER assembly.
+        ds.data['2026-06-06T12:00:00+02:00']['NO2'] = 999.0
+        ds.data['2026-06-06T13:00:00+02:00'] = {'NO2': 1000.0}
+
+        # Envelope must be unchanged.
+        assert envelope.data['L1']['2026-06-06T12:00:00+02:00']['NO2'] == 20.0
+        assert '2026-06-06T13:00:00+02:00' not in envelope.data['L1']
+
+
+class TestInputValidation:
+    """PR #20 review MINOR: silent zip-truncation on mismatched input
+    lengths would drop the tail of buurt_aq_data without notice.
+    """
+
+    def test_length_mismatch_raises(self):
+        locs = [
+            {'name': 'L1', 'lat': 52.0, 'lon': 4.0},
+            {'name': 'L2', 'lat': 52.1, 'lon': 4.1},
+        ]
+        ds = _ds('NL001', {'2026-06-06T12:00:00+02:00': {'NO2': 20.0}})
+        with pytest.raises(ValueError, match="length mismatch"):
+            assemble_buurt_air_envelope(locs, [ds])  # 2 locs vs 1 result
 
 
 class TestQualityIssueAggregation:


### PR DESCRIPTION
## Summary

Wrap \`air_quality_buurt.json\` in the same \`{metadata, data: {<loc>: ...}}\` envelope used by \`weather_forecast_buurt.json\` and \`solar_forecast_buurt.json\`. Closes #17.

## Why this matters

Different envelope shapes forced every downstream consumer to special-case the air-quality file. FyE silently reported \`available: []\` after PR #10's cron ran — its \`_extract_data_block\` was looking at \`payload[\"data\"]\` (absent) instead of \`payload[<loc>]\`. The data was published correctly; the consumer just couldn't find it. Every future consumer would hit the same trap.

## What changed

- **Extracted** \`assemble_buurt_air_envelope(buurt_locations, buurt_aq_data)\` helper at the top of \`data_fetcher.py\`. Combines N per-location Luchtmeetnet \`EnhancedDataSet\`s into a single \`EnhancedDataSet\` whose \`data\` is keyed by location — matching the weather/solar buurt shape exactly.
- **Replaced** the inline \`CombinedDataSet\` assembly + the downstream \`.datasets\` reference at line 866.
- Per-location station info (RIVM station number + coords + city) preserved in \`metadata['stations'][<loc>]\`.
- Per-location \`collector_quality_issues\` (from #12 / PR #16) aggregated to top-level \`metadata['collector_quality_issues']\` with \`details.location\` tag so the pipeline data-quality gate still sees them after the flatten.

## Back-compat / blast radius

- **Internal consumers**: only \`data_fetcher.py\` writes the file; the workflow just \`cp\`s it into \`docs/\`. No internal reader breaks.
- **External**: FyE side already normalises both shapes via \`_extract_data_block\` — after this PR it hits the standard \`payload[\"data\"][<loc>]\` path. No other known consumers.

## Tests

10 new tests in \`tests/unit/test_buurt_air_envelope.py\` pin the envelope shape so future refactors can't silently regress it:

- **Shape**: top-level \`{metadata, data}\`, NOT \`{version, ...}\`; \`data\` keyed by location name; \`data\` is on the returned \`EnhancedDataSet\` (not \`.datasets\`).
- **Station preservation**: \`metadata.stations[<loc>]\` populated per location.
- **Quality issues**: per-location \`collector_quality_issues\` aggregate with \`details.location\` tag; absent when all clean.
- **Defensive**: total outage returns \`None\`; partial success includes only succeeded locations.

Full suite: **408 passed**.

## Test plan

- [x] \`python -m pytest tests/unit/test_buurt_air_envelope.py -v\` (10 passed)
- [x] \`python -m pytest tests/\` (408 passed)
- [ ] Manual: trigger workflow_dispatch after merge, eyeball \`docs/air_quality_buurt.json\` shape

Closes #17. Follow-up to #10. Sibling PRs: #16 (Luchtmeetnet bundle), #18 (Open-Meteo shared semaphore), #19 (closest defense-in-depth).