### PR TITLE
ci: skip global coverage gate on filtered timezone-only test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,12 @@ jobs:
 
     - name: Run critical timezone tests only
       run: |
-        python -m pytest tests/ -v -m critical
+        # --no-cov: the 20% --cov-fail-under gate in pytest.ini applies to
+        # the FULL suite (run by the previous step). This filtered slice
+        # runs ~19 timezone-marked tests; measuring global coverage off
+        # those would always be near-zero and brittle to any small
+        # uncovered addition. See email-noise incident after PR #16 merge.
+        python -m pytest tests/ -v -m critical --no-cov
 
   code-quality:
     name: Code Quality Checks


### PR DESCRIPTION
## Summary

One-line CI fix in \`.github/workflows/test.yml\`. The \"Run critical timezone tests only\" job applies the global 20% coverage gate from \`pytest.ini\` to a slice of just ~19 tests, so any small uncovered addition can dip total coverage below threshold and fail this job — even when the full-suite job passes.

## What happened

After PR #16 merged (commit 1455bba), this filtered job measured 19.50% global coverage and failed. The subsequent PR #18 and PR #20 merges added more covered code and pushed it back above 20%, so HEAD of main was always green. Only the intermediate commit looked broken — but it generated email noise.

## Fix

Add \`--no-cov\` to the filtered job's pytest invocation. The full-suite job (\"Run Tests with Python 3.12\") continues to enforce the 20% gate.

## Test plan

- [x] CI runs on this PR — both jobs (full + filtered) green
- [ ] Future merges that briefly drop coverage on intermediate commits won't generate email noise

Closes the email-noise issue from the post-PR-#16 merge.