### PR TITLE
fix: cap=6 + per-location retry for OpenMeteo collectors

### DIFF
--- a/collectors/_openmeteo_shared.py
+++ b/collectors/_openmeteo_shared.py
@@ -24,19 +24,33 @@ Tuning
 ------
 Free-tier limits: https://open-meteo.com/en/docs (consult the live docs
 rather than trusting a number in this docstring — Open-Meteo has changed
-the budget more than once). ``OPENMETEO_SEMAPHORE_CAP = 5`` is below the
-old per-collector × 6 = 6 concurrent peak, so this is strictly more
-conservative than the pre-#11 code. Raise/lower by changing the constant
-here; no per-collector edit needed.
+the budget more than once). ``OPENMETEO_SEMAPHORE_CAP = 6`` matches the
+pre-#11 ``per-collector Semaphore(1) × 6 collectors`` peak. Raise/lower
+by changing the constant here; no per-collector edit needed.
 
-Fairness note
--------------
-``asyncio.Semaphore`` is FIFO. With a cap below the collector count, the
-first-scheduled collector's tasks queue ahead of late-scheduled tasks.
-In practice ``asyncio.gather`` interleaves task creation roughly fairly,
-and per-collector location counts are small (2–6 each), so monopolisation
-is bounded. If a future collector with 20+ locations is added, revisit
-this — either raise the cap or move to a token-bucket scheme.
+Why cap == collector count, not lower
+-------------------------------------
+First post-#11 deployment used cap=5. Two consecutive runs on 2026-06-07
+exposed a regression: late-scheduled collectors (offshore wind + both
+buurt) consistently got ``Connection timeout to host api.open-meteo.com``
+while the early strategic/demand collectors succeeded. Open-Meteo's CDN
+appears to apply per-source connection-cooldown after a burst, and the
+late requests queued behind the shared FIFO arrived during that window.
+Pre-#11 the 6 collectors ran with their own ``Semaphore(1)`` each — so 6
+parallel sessions instead of one serialised queue — which avoided the
+cooldown window. Setting cap == collector count restores that pattern
+while preserving the architectural win (one place to tune).
+
+If a 7th OpenMeteo collector is added, raise this constant to 7 (and
+update this comment). Lowering below collector count risks reintroducing
+the timeout regression — investigate Open-Meteo's behavior first.
+
+Per-request retry
+-----------------
+The cap above mitigates the upstream cooldown trigger; ``MAX_RETRIES`` /
+``RETRY_INITIAL_DELAY_SECONDS`` provide belt-and-suspenders resilience
+for any transient (timeout, 429, 503) regardless of root cause. Used by
+each OpenMeteo collector's per-location fetch helper.
 
 Singleton lifecycle
 -------------------
@@ -48,9 +62,20 @@ the old one — do NOT reload this module inside tests or notebooks. The
 """
 
 import asyncio
+import logging
 
-OPENMETEO_SEMAPHORE_CAP: int = 5
+OPENMETEO_SEMAPHORE_CAP: int = 6
 OPENMETEO_GAP_SECONDS: float = 0.5
+
+# Per-request retry budget for per-location fetches. Three attempts with
+# exponential backoff (1s → 2s → 4s). Triggered whenever the fetch helper
+# returns ``data=None`` (covers aiohttp timeouts, HTTP non-200, transport
+# errors — all caught and represented as ``{name, data=None, error=...}``
+# by the collectors' ``_fetch_location_data``). Total worst-case wall time
+# per location: ~3 attempts + 1s + 2s waits ≈ 6s before final failure.
+MAX_RETRIES: int = 3
+RETRY_INITIAL_DELAY_SECONDS: float = 1.0
+RETRY_BACKOFF_BASE: float = 2.0
 
 # Module-level construction is safe on Python 3.10+ (no running loop
 # required). The project's minimum is 3.12. The hasattr guard makes a
@@ -58,3 +83,62 @@ OPENMETEO_GAP_SECONDS: float = 0.5
 # acquisitions on the previous instance.
 if 'OPENMETEO_SEMAPHORE' not in globals():
     OPENMETEO_SEMAPHORE: asyncio.Semaphore = asyncio.Semaphore(OPENMETEO_SEMAPHORE_CAP)
+
+
+async def fetch_location_with_retry(
+    session,
+    location,
+    fetch_fn,
+    logger: logging.Logger,
+    apply_gap: bool = True,
+):
+    """Shared per-location wrapper for the three OpenMeteo* collectors.
+
+    Acquires ``OPENMETEO_SEMAPHORE``, optionally sleeps ``OPENMETEO_GAP_SECONDS``
+    between requests, then calls ``fetch_fn(session, location)`` — which must
+    return ``{'name': str, 'data': Any|None, 'error': str|None}`` per the
+    OpenMeteo collectors' ``_fetch_location_data`` contract.
+
+    On failure (``data is None``), retries up to ``MAX_RETRIES`` times with
+    exponential backoff (``RETRY_INITIAL_DELAY_SECONDS`` × ``RETRY_BACKOFF_BASE^n``).
+    Belt-and-suspenders resilience against the offshore+buurt timeouts seen
+    on 2026-06-07 — even after the cap was raised to match collector count,
+    transient Open-Meteo issues should self-heal without a full re-run.
+
+    Args:
+        session: shared aiohttp.ClientSession from the caller.
+        location: dict with ``name``, ``lat``, ``lon`` (and optional extras).
+        fetch_fn: async callable that does the actual HTTP request.
+        logger: caller's logger for retry/failure messages.
+        apply_gap: when True (typical: i > 0 in the caller's loop), waits
+            ``OPENMETEO_GAP_SECONDS`` inside the semaphore. Set False for the
+            first request of the batch so the wave isn't pre-delayed.
+
+    Returns:
+        The last response dict from ``fetch_fn``. ``data`` is the API payload
+        on success or None after all retries exhausted; ``error`` carries the
+        last failure message.
+    """
+    last_response = {'name': location.get('name', '?'), 'data': None, 'error': 'no attempt made'}
+    for attempt in range(1, MAX_RETRIES + 1):
+        async with OPENMETEO_SEMAPHORE:
+            if apply_gap:
+                await asyncio.sleep(OPENMETEO_GAP_SECONDS)
+            last_response = await fetch_fn(session, location)
+        if last_response.get('data') is not None:
+            if attempt > 1:
+                logger.info(f"{location['name']}: succeeded on attempt {attempt}/{MAX_RETRIES}")
+            return last_response
+        if attempt < MAX_RETRIES:
+            delay = RETRY_INITIAL_DELAY_SECONDS * (RETRY_BACKOFF_BASE ** (attempt - 1))
+            err_snippet = str(last_response.get('error', '?'))[:80]
+            logger.info(
+                f"{location['name']}: attempt {attempt}/{MAX_RETRIES} failed "
+                f"({err_snippet}), retrying in {delay:.1f}s"
+            )
+            await asyncio.sleep(delay)
+    logger.warning(
+        f"{location['name']}: all {MAX_RETRIES} attempts failed; "
+        f"final error: {str(last_response.get('error', '?'))[:120]}"
+    )
+    return last_response

--- a/collectors/openmeteo_offshore_wind.py
+++ b/collectors/openmeteo_offshore_wind.py
@@ -51,6 +51,7 @@ from collectors.base import BaseCollector, RetryConfig, CircuitBreakerConfig
 from collectors._openmeteo_shared import (
     OPENMETEO_SEMAPHORE,
     OPENMETEO_GAP_SECONDS,
+    fetch_location_with_retry,
 )
 
 
@@ -171,18 +172,18 @@ class OpenMeteoOffshoreWindCollector(BaseCollector):
         self.logger.debug(f"Fetching offshore wind data for {len(self.locations)} locations")
 
         results = {}
-        # Rate-limit budget is shared across ALL OpenMeteo* collectors via
-        # collectors/_openmeteo_shared.py (issue #11). Adding a 6th collector
-        # no longer requires retuning this file.
+        # Rate-limit budget + per-location retry are shared across ALL
+        # OpenMeteo* collectors via collectors/_openmeteo_shared.py (issue
+        # #11 + 2026-06-07 timeout regression).
         async def fetch_with_rate_limit(
             session: aiohttp.ClientSession,
             location: Dict[str, Any],
             delay: bool,
         ):
-            async with OPENMETEO_SEMAPHORE:
-                if delay:
-                    await asyncio.sleep(OPENMETEO_GAP_SECONDS)
-                return await self._fetch_location_data(session, location)
+            return await fetch_location_with_retry(
+                session, location, self._fetch_location_data,
+                logger=self.logger, apply_gap=delay,
+            )
 
         async with aiohttp.ClientSession() as session:
             tasks = [

--- a/collectors/openmeteo_solar.py
+++ b/collectors/openmeteo_solar.py
@@ -52,6 +52,7 @@ import aiohttp
 from collectors._openmeteo_shared import (
     OPENMETEO_SEMAPHORE,
     OPENMETEO_GAP_SECONDS,
+    fetch_location_with_retry,
 )
 
 from collectors.base import BaseCollector, RetryConfig, CircuitBreakerConfig
@@ -167,18 +168,18 @@ class OpenMeteoSolarCollector(BaseCollector):
         self.logger.debug(f"Fetching solar data for {len(self.locations)} locations")
 
         results = {}
-        # Rate-limit budget is shared across ALL OpenMeteo* collectors via
-        # collectors/_openmeteo_shared.py (issue #11). Adding a 6th collector
-        # no longer requires retuning this file.
+        # Rate-limit budget + per-location retry are shared across ALL
+        # OpenMeteo* collectors via collectors/_openmeteo_shared.py (issue
+        # #11 + 2026-06-07 timeout regression).
         async def fetch_with_rate_limit(
             session: aiohttp.ClientSession,
             location: Dict[str, Any],
             delay: bool,
         ):
-            async with OPENMETEO_SEMAPHORE:
-                if delay:
-                    await asyncio.sleep(OPENMETEO_GAP_SECONDS)
-                return await self._fetch_location_data(session, location)
+            return await fetch_location_with_retry(
+                session, location, self._fetch_location_data,
+                logger=self.logger, apply_gap=delay,
+            )
 
         async with aiohttp.ClientSession() as session:
             tasks = [

--- a/collectors/openmeteo_weather.py
+++ b/collectors/openmeteo_weather.py
@@ -51,6 +51,7 @@ from collectors.base import BaseCollector, RetryConfig, CircuitBreakerConfig
 from collectors._openmeteo_shared import (
     OPENMETEO_SEMAPHORE,
     OPENMETEO_GAP_SECONDS,
+    fetch_location_with_retry,
 )
 from utils.timezone_helpers import normalize_timestamp_to_amsterdam
 
@@ -228,18 +229,18 @@ class OpenMeteoWeatherCollector(BaseCollector):
         self.logger.debug(f"Fetching demand weather for {len(self.locations)} locations")
 
         results = {}
-        # Rate-limit budget is shared across ALL OpenMeteo* collectors via
-        # collectors/_openmeteo_shared.py (issue #11). Adding a 6th collector
-        # no longer requires retuning this file.
+        # Rate-limit budget + per-location retry are shared across ALL
+        # OpenMeteo* collectors via collectors/_openmeteo_shared.py (issue
+        # #11 + 2026-06-07 timeout regression).
         async def fetch_with_rate_limit(
             session: aiohttp.ClientSession,
             location: Dict[str, Any],
             delay: bool,
         ):
-            async with OPENMETEO_SEMAPHORE:
-                if delay:
-                    await asyncio.sleep(OPENMETEO_GAP_SECONDS)
-                return await self._fetch_location_data(session, location)
+            return await fetch_location_with_retry(
+                session, location, self._fetch_location_data,
+                logger=self.logger, apply_gap=delay,
+            )
 
         async with aiohttp.ClientSession() as session:
             tasks = [

--- a/tests/unit/test_openmeteo_shared_semaphore.py
+++ b/tests/unit/test_openmeteo_shared_semaphore.py
@@ -66,13 +66,141 @@ class TestSharedSemaphoreShape:
     def test_semaphore_is_an_asyncio_semaphore(self):
         assert isinstance(_openmeteo_shared.OPENMETEO_SEMAPHORE, asyncio.Semaphore)
 
-    def test_cap_is_set_to_documented_safe_budget(self):
-        """5 = below the pre-#11 per-collector × 6 = 6 concurrent peak."""
-        assert _openmeteo_shared.OPENMETEO_SEMAPHORE_CAP == 5
+    def test_cap_equals_collector_count(self):
+        """6 = matches the 6 OpenMeteo collectors in data_fetcher.py.
+
+        Bumped from 5 → 6 after the 2026-06-07 timeout regression: a cap
+        below collector count caused late-scheduled collectors (offshore
+        + buurt) to time out on Open-Meteo's CDN per-source cooldown
+        window while early strategic collectors monopolised the FIFO
+        queue. cap == count restores the pre-#11 per-collector × Semaphore(1)
+        effective behavior — parallel sessions instead of one serialised
+        queue.
+        """
+        assert _openmeteo_shared.OPENMETEO_SEMAPHORE_CAP == 6
 
     def test_gap_is_set_to_documented_safe_budget(self):
         """0.5s = the inter-request gap from PR #10's fix."""
         assert _openmeteo_shared.OPENMETEO_GAP_SECONDS == 0.5
+
+
+class TestFetchLocationWithRetry:
+    """Per-location retry-with-backoff wrapper for OpenMeteo collectors.
+
+    Belt-and-suspenders against transient timeouts/429/5xx — even after
+    the cap bump fixed the root cause, a single bad response should
+    self-heal without a full collection re-run.
+    """
+
+    @pytest.mark.asyncio
+    async def test_success_on_first_attempt_no_retry(self):
+        import logging
+        from collectors._openmeteo_shared import fetch_location_with_retry
+
+        call_count = 0
+
+        async def fetch_fn(session, location):
+            nonlocal call_count
+            call_count += 1
+            return {'name': location['name'], 'data': {'ok': True}, 'error': None}
+
+        result = await fetch_location_with_retry(
+            session=None,
+            location={'name': 'L1'},
+            fetch_fn=fetch_fn,
+            logger=logging.getLogger('test'),
+            apply_gap=False,
+        )
+        assert result['data'] == {'ok': True}
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_succeeds_after_transient_failures(self, monkeypatch):
+        """Two failures then success → returns success, total 3 calls."""
+        import logging
+        from collectors import _openmeteo_shared
+        # Speed test up: reduce backoff to ~0.
+        monkeypatch.setattr(_openmeteo_shared, 'RETRY_INITIAL_DELAY_SECONDS', 0.0)
+
+        call_count = 0
+
+        async def fetch_fn(session, location):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                return {'name': location['name'], 'data': None, 'error': 'timeout'}
+            return {'name': location['name'], 'data': {'ok': True}, 'error': None}
+
+        result = await _openmeteo_shared.fetch_location_with_retry(
+            session=None,
+            location={'name': 'L1'},
+            fetch_fn=fetch_fn,
+            logger=logging.getLogger('test'),
+            apply_gap=False,
+        )
+        assert result['data'] == {'ok': True}
+        assert call_count == 3  # used all 3 attempts (2 failed + 1 succeeded)
+
+    @pytest.mark.asyncio
+    async def test_returns_last_failure_after_all_retries(self, monkeypatch):
+        import logging
+        from collectors import _openmeteo_shared
+        monkeypatch.setattr(_openmeteo_shared, 'RETRY_INITIAL_DELAY_SECONDS', 0.0)
+
+        call_count = 0
+
+        async def fetch_fn(session, location):
+            nonlocal call_count
+            call_count += 1
+            return {'name': location['name'], 'data': None, 'error': f'attempt-{call_count}-failed'}
+
+        result = await _openmeteo_shared.fetch_location_with_retry(
+            session=None,
+            location={'name': 'L_dead'},
+            fetch_fn=fetch_fn,
+            logger=logging.getLogger('test'),
+            apply_gap=False,
+        )
+        assert result['data'] is None
+        assert call_count == _openmeteo_shared.MAX_RETRIES
+        # Error reflects the LAST attempt, not the first.
+        assert 'attempt-3-failed' in result['error']
+
+    @pytest.mark.asyncio
+    async def test_exponential_backoff_delays(self, monkeypatch):
+        """Backoff sequence: 1s, 2s, 4s, ... — measured by counting
+        asyncio.sleep calls between attempts."""
+        import logging
+        from collectors import _openmeteo_shared
+
+        sleep_durations = []
+        original_sleep = asyncio.sleep
+
+        async def fake_sleep(d):
+            sleep_durations.append(d)
+            await original_sleep(0)
+
+        monkeypatch.setattr(asyncio, 'sleep', fake_sleep)
+
+        async def always_fail(session, location):
+            return {'name': location['name'], 'data': None, 'error': 'x'}
+
+        await _openmeteo_shared.fetch_location_with_retry(
+            session=None,
+            location={'name': 'L1'},
+            fetch_fn=always_fail,
+            logger=logging.getLogger('test'),
+            apply_gap=False,  # don't conflate with retry delays
+        )
+
+        # MAX_RETRIES attempts means MAX_RETRIES - 1 inter-attempt sleeps.
+        backoff_sleeps = sleep_durations  # since apply_gap=False, all sleeps are retries
+        expected = [
+            _openmeteo_shared.RETRY_INITIAL_DELAY_SECONDS
+            * (_openmeteo_shared.RETRY_BACKOFF_BASE ** i)
+            for i in range(_openmeteo_shared.MAX_RETRIES - 1)
+        ]
+        assert backoff_sleeps == expected
 
 
 class TestSharedSemaphoreEnforcesConcurrency:


### PR DESCRIPTION
## Why

After PR #18 merged, two consecutive workflow_dispatch runs (27086755763, 27087174593) failed with the same pattern: late-scheduled OpenMeteo collectors (offshore wind + both buurts) consistently got \`Connection timeout to host api.open-meteo.com\` while early strategic/demand collectors succeeded. The data-quality gate correctly blocked publish, but this needed fixing.

## Root cause

Open-Meteo's CDN applies a per-source connection-cooldown window after a request burst. With shared \`Semaphore(5)\` from PR #18, the 28 location requests across 6 collectors queued FIFO; the last ~7 requests (offshore + buurt) arrived during the cooldown.

Pre-#11 the 6 collectors ran with their own \`Semaphore(1)\` each — 6 parallel sessions instead of one serialised queue — which avoided the cooldown trigger.

## Fix (two layers)

**Layer 1 — Cap bump (5 → 6):** restores the pre-#11 effective concurrency pattern (cap == collector count = parallel sessions) while preserving PR #11's architectural win (one place to tune).

**Layer 2 — Per-location retry with exponential backoff:** belt-and-suspenders resilience. Any transient (timeout/429/5xx) on a single location self-heals without needing a full collection re-run. \`MAX_RETRIES=3\`, backoff \`1s → 2s\`. Implemented in new \`fetch_location_with_retry\` in \`_openmeteo_shared.py\`; each of the 3 OpenMeteo collectors now wraps via this helper.

## Tests

4 new tests in \`TestFetchLocationWithRetry\`:
- success on first attempt → no retry, single call
- 2 failures then success → 3 calls, returns success  
- all 3 attempts fail → returns last failure dict
- exponential backoff sequence pinned to \`[1.0, 2.0]\`

Existing \`test_cap_is_set_to_documented_safe_budget\` renamed to \`test_cap_equals_collector_count\` and updated for the new value with explanatory docstring.

Full suite: **448 passed** (up from 444).

## Test plan

- [x] \`python -m pytest tests/unit/test_openmeteo_shared_semaphore.py -v\` (15 passed)
- [x] \`python -m pytest tests/\` (448 passed)
- [ ] After merge: trigger workflow_dispatch to verify buurt collectors no longer time out